### PR TITLE
Account for menuInsets when using sizeToFit

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -219,9 +219,10 @@ public class PagingViewController<T: PagingItem where T: Equatable>:
   
   public func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
     if case .SizeToFit = options.menuItemSize {
-      if dataStructure.totalWidth < collectionView.bounds.width {
+      let inset = options.menuInsets.left + options.menuInsets.right
+      if dataStructure.totalWidth + inset < collectionView.bounds.width {
         return CGSize(
-          width: collectionView.bounds.width / CGFloat(dataStructure.visibleItems.count),
+          width: (collectionView.bounds.width - inset) / CGFloat(dataStructure.visibleItems.count),
           height: options.menuItemSize.height)
       }
     }


### PR DESCRIPTION
Previously, if the user specified non-zero left and/or right `menuInsets` & used `.SizeToFit` for `menuItemSize`, it would cause the menu to be horizontal scrollable, even if the min width + insets fit inside the available space.

Now the fitting check calculation includes the inset, and also subtracts the inset before dividing the available space, ensuring that when possible, the menu will not scroll.