### PR TITLE
Centering

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -230,6 +230,26 @@ public class PagingViewController<T: PagingItem where T: Equatable>:
       width: widthForPagingItem(dataStructure.pagingItemForIndexPath(indexPath)),
       height: options.menuItemSize.height)
   }
+    
+  public func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAtIndex section: Int) -> UIEdgeInsets {
+    switch options.menuHorizontalAlignment {
+    case .Center:
+      if case .SizeToFit = options.menuItemSize {
+        return options.menuInsets
+      }
+      var itemsWidth: CGFloat = 0.0
+      for index in dataStructure.visibleItems.indices {
+        let indexPath = NSIndexPath(forItem: index, inSection: section)
+        itemsWidth += widthForPagingItem(dataStructure.pagingItemForIndexPath(indexPath))
+      }
+      let itemSpacing = options.menuItemSpacing * CGFloat(dataStructure.visibleItems.count - 1)
+      let padding = collectionView.bounds.width - itemsWidth - itemSpacing
+      let horizontalInset = max(0, padding) / 2
+      return UIEdgeInsets(top: 0, left: horizontalInset, bottom: 0, right: horizontalInset)
+    case .Default:
+      return options.menuInsets
+    }
+  }
   
   public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
     guard let stateMachine = stateMachine else { return }

--- a/Parchment/Enums/PagingOptions.swift
+++ b/Parchment/Enums/PagingOptions.swift
@@ -45,6 +45,11 @@ public enum PagingSelectedScrollPosition {
   case PreferCentered
 }
 
+public enum PagingMenuHorizontalAlignment {
+  case Default
+  case Center
+}
+
 public protocol PagingTheme {
   var font: UIFont { get }
   var textColor: UIColor { get }
@@ -60,6 +65,7 @@ public protocol PagingOptions {
   var menuItemClass: PagingCell.Type { get }
   var menuItemSpacing: CGFloat { get }
   var menuInsets: UIEdgeInsets { get }
+  var menuHorizontalAlignment: PagingMenuHorizontalAlignment { get }
   var selectedScrollPosition: PagingSelectedScrollPosition { get }
   var indicatorOptions: PagingIndicatorOptions { get }
   var borderOptions: PagingBorderOptions { get }
@@ -157,6 +163,9 @@ public extension PagingOptions {
     return 0
   }
   
+  var menuHorizontalAlignment: PagingMenuHorizontalAlignment {
+    return .Default
+  }
 }
 
 struct DefaultPagingTheme: PagingTheme {}

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ protocol PagingOptions {
   var menuItemClass: PagingCell.Type { get }
   var menuItemSpacing: CGFloat { get }
   var menuInsets: UIEdgeInsets { get }
+  var menuHorizontalAlignment: PagingMenuHorizontalAlignment { get }
   var selectedScrollPosition: PagingSelectedScrollPosition { get }
   var indicatorOptions: PagingIndicatorOptions { get }
   var borderOptions: PagingBorderOptions { get }
@@ -185,6 +186,23 @@ _Default: `0`_
 The insets around all of the menu items.
 
 _Default: `UIEdgeInsets()`_
+
+#### `menuAlignment`
+  
+
+
+```Swift
+public enum PagingMenuHorizontalAlignment {
+  case Default
+
+  // Allows all paging items to be centered within the paging menu
+  // when PagingMenuItemSize is .Fixed and the sum of the widths
+  // of all the paging items are less than the paging menu
+  case Center 
+}
+```
+
+_Default: `.Default`_
 
 #### `PagingSelectedScrollPosition`
 


### PR DESCRIPTION
We ran into this issue with a feature in Flow and thought it might be a good addition to the framework. In our case simply using the `menuItemInset` was insufficient because the inset needs to change when the app is rotated.  This addition should only affect users that add the new property and have fixed width paging items and where there paging items widths are less than the menu.  

If you don't feel like this fits with your vision for Parchment just let me know and we can simply use the fork in our project.