### PR TITLE
Fix issue with missing selected state

### DIFF
--- a/CalendarExample/CalendarPagingCell.swift
+++ b/CalendarExample/CalendarPagingCell.swift
@@ -27,12 +27,6 @@ class CalendarPagingCell: PagingCell {
     configure()
   }
   
-  override var isSelected: Bool {
-    didSet {
-      updateSelectedState()
-    }
-  }
-  
   fileprivate func configure() {
     addSubview(dateLabel)
     addSubview(weekdayLabel)
@@ -84,9 +78,9 @@ class CalendarPagingCell: PagingCell {
     ])
   }
   
-  fileprivate func updateSelectedState() {
+  fileprivate func updateSelectedState(selected: Bool) {
     guard let theme = theme else { return }
-    if isSelected {
+    if selected {
       dateLabel.textColor = theme.selectedTextColor
       weekdayLabel.textColor = theme.selectedTextColor
     } else {
@@ -95,13 +89,15 @@ class CalendarPagingCell: PagingCell {
     }
   }
   
-  override func setPagingItem(_ pagingItem: PagingItem, theme: PagingTheme) {
+  override func setPagingItem(_ pagingItem: PagingItem, selected: Bool, theme: PagingTheme) {
     let calendarItem = pagingItem as! CalendarItem
     dateLabel.text = DateFormatters.dateFormatter.string(from: calendarItem.date)
     weekdayLabel.text = DateFormatters.weekdayFormatter.string(from: calendarItem.date)
     
     self.theme = theme
-    updateSelectedState()
+    updateSelectedState(selected: selected)
+  }
+  
   override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
     super.apply(layoutAttributes)
     guard let theme = theme else { return }

--- a/Parchment/Classes/PagingCell.swift
+++ b/Parchment/Classes/PagingCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 open class PagingCell: UICollectionViewCell {
-  open func setPagingItem(_ pagingItem: PagingItem, theme: PagingTheme) {
+  open func setPagingItem(_ pagingItem: PagingItem, selected: Bool, theme: PagingTheme) {
     fatalError("setPagingItem: not implemented")
   }
 }

--- a/Parchment/Classes/PagingTitleCell.swift
+++ b/Parchment/Classes/PagingTitleCell.swift
@@ -21,9 +21,12 @@ open class PagingTitleCell: PagingCell {
     configure()
   }
   
-  open override func setPagingItem(_ pagingItem: PagingItem, theme: PagingTheme) {
+  open override func setPagingItem(_ pagingItem: PagingItem, selected: Bool, theme: PagingTheme) {
     if let titleItem = pagingItem as? PagingTitleItem {
-      viewModel = PagingTitleCellViewModel(title: titleItem.title, theme: theme)
+      viewModel = PagingTitleCellViewModel(
+        title: titleItem.title,
+        selected: selected,
+        theme: theme)
     }
     configureTitleLabel()
   }
@@ -39,7 +42,7 @@ open class PagingTitleCell: PagingCell {
     titleLabel.font = viewModel.font
     titleLabel.textAlignment = .center
     
-    if isSelected {
+    if viewModel.selected {
       titleLabel.textColor = viewModel.selectedTextColor
     } else {
       titleLabel.textColor = viewModel.textColor

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -268,7 +268,9 @@ open class PagingViewController<T: PagingItem>:
   
   public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
     let cell = collectionView.dequeueReusableCell(indexPath: indexPath, cellType: options.menuItemClass)
-    cell.setPagingItem(dataStructure.visibleItems[indexPath.item], theme: options.theme)
+    let pagingItem = dataStructure.visibleItems[indexPath.item]
+    let selected = stateMachine?.state.currentPagingItem == pagingItem
+    cell.setPagingItem(pagingItem, selected: selected, theme: options.theme)
     return cell
   }
   

--- a/Parchment/Structs/PagingCellViewModel.swift
+++ b/Parchment/Structs/PagingCellViewModel.swift
@@ -6,12 +6,14 @@ struct PagingTitleCellViewModel {
   let font: UIFont
   let textColor: UIColor
   let selectedTextColor: UIColor
+  let selected: Bool
   
-  init(title: String?, theme: PagingTheme) {
+  init(title: String?, selected: Bool, theme: PagingTheme) {
     self.title = title
     self.font = theme.font
     self.textColor = theme.textColor
     self.selectedTextColor = theme.selectedTextColor
+    self.selected = selected
   }
   
 }

--- a/UnplashExample/ImagePagingCell.swift
+++ b/UnplashExample/ImagePagingCell.swift
@@ -39,12 +39,20 @@ class ImagePagingCell: PagingCell {
     fatalError("init(coder:) has not been implemented")
   }
   
-  override func setPagingItem(_ pagingItem: PagingItem, theme: PagingTheme) {
+  override func setPagingItem(_ pagingItem: PagingItem, selected: Bool, theme: PagingTheme) {
     let item = pagingItem as! ImageItem
     imageView.image = item.headerImage
     titleLabel.attributedText = NSAttributedString(
       string: item.title,
       attributes: [NSParagraphStyleAttributeName: paragraphStyle])
+    
+    if selected {
+      imageView.transform = CGAffineTransform(scaleX: 2, y: 2)
+    } else {
+      imageView.transform = CGAffineTransform.identity
+    }
+  }
+  
   open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
     if let attributes = layoutAttributes as? PagingCellLayoutAttributes {
       let scale = 1 + attributes.progress


### PR DESCRIPTION
When highlighting other cells, the default selected property on
UICollectionViewCell is set to false. In order fix this we pass in the
selected state to the setPagingItem method. The selected state is
based on the current paging state.