### PR TITLE
Scroll menu items alongside content

### DIFF
--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		3ED1C8D81CC1554E00B46885 /* PagingItemPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ED1C8D71CC1554E00B46885 /* PagingItemPresentable.swift */; };
 		3EF3C1E31CA0870E00CDFE26 /* FixedPagingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF3C1E21CA0870E00CDFE26 /* FixedPagingViewController.swift */; };
 		3EFEFBF71C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift */; };
+		952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952D802E1E37CC09003DCB18 /* PagingTransition.swift */; };
 		957F14091E35583500E562F8 /* PagingCellLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */; };
 		9597F2951E3903F4003FD289 /* UIColor+interpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597F2941E3903F4003FD289 /* UIColor+interpolation.swift */; };
 		9597F2971E390519003FD289 /* UIColor+interpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597F2961E390519003FD289 /* UIColor+interpolation.swift */; };
@@ -262,6 +263,7 @@
 		3ED1C8D71CC1554E00B46885 /* PagingItemPresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingItemPresentable.swift; sourceTree = "<group>"; };
 		3EF3C1E21CA0870E00CDFE26 /* FixedPagingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FixedPagingViewController.swift; sourceTree = "<group>"; };
 		3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingIndicatorLayoutAttributesSpec.swift; sourceTree = "<group>"; };
+		952D802E1E37CC09003DCB18 /* PagingTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingTransition.swift; sourceTree = "<group>"; };
 		957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingCellLayoutAttributes.swift; sourceTree = "<group>"; };
 		9597F2941E3903F4003FD289 /* UIColor+interpolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+interpolation.swift"; sourceTree = "<group>"; };
 		9597F2961E390519003FD289 /* UIColor+interpolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+interpolation.swift"; sourceTree = "<group>"; };
@@ -370,6 +372,7 @@
 				3E49C72D1C8F5CCE006269DD /* PagingCellViewModel.swift */,
 				3E4090A11C88BD0A00800E22 /* PagingIndicatorMetric.swift */,
 				3E4283FB1C99CF9000032D95 /* PagingDataStructure.swift */,
+				952D802E1E37CC09003DCB18 /* PagingTransition.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -860,6 +863,7 @@
 				3E2AAD2C1CA869B50044AAA5 /* PagingItem.swift in Sources */,
 				3E40909C1C88BCC900800E22 /* PagingOptions.swift in Sources */,
 				3E4090B11C88BDD100800E22 /* PagingIndicatorLayoutAttributes.swift in Sources */,
+				952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */,
 				3E4090AE1C88BDD100800E22 /* PagingBorderLayoutAttributes.swift in Sources */,
 				3E4283FC1C99CF9000032D95 /* PagingDataStructure.swift in Sources */,
 				3E49C7281C8F5C13006269DD /* PagingIndicatorView.swift in Sources */,

--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -103,7 +103,7 @@ open class PagingCollectionViewLayout<T: PagingItem>: UICollectionViewFlowLayout
         frame: indicatorFrameForIndex(upcomingIndexPath.item),
         insets: indicatorInsetsForIndex(upcomingIndexPath.item))
       
-      indicatorLayoutAttributes.update(from: from, to: to, progress: fabs(state.offset))
+      indicatorLayoutAttributes.update(from: from, to: to, progress: fabs(state.progress))
       return indicatorLayoutAttributes
     }
     
@@ -127,9 +127,9 @@ open class PagingCollectionViewLayout<T: PagingItem>: UICollectionViewFlowLayout
     let upcomingIndexPath = upcomingIndexPathForIndexPath(currentIndexPath)
     switch indexPath.item {
     case currentIndexPath.item:
-      return 1 - fabs(state.offset)
+      return 1 - fabs(state.progress)
     case upcomingIndexPath.item:
-      return fabs(state.offset)
+      return fabs(state.progress)
     default:
       return 0
     }

--- a/Parchment/Classes/PagingStateMachine.swift
+++ b/Parchment/Classes/PagingStateMachine.swift
@@ -20,10 +20,10 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
   
   func fire(_ event: PagingEvent<T>) {
     switch event {
-    case let .scroll(offset):
+    case let .scroll(progress):
       handleScrollEvent(
         event,
-        offset: offset)
+        progress: progress)
     case let .select(pagingItem, direction, animated):
       handleSelectEvent(
         event,
@@ -37,34 +37,34 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
     }
   }
   
-  fileprivate func handleScrollEvent(_ event: PagingEvent<T>, offset: CGFloat) {
+  fileprivate func handleScrollEvent(_ event: PagingEvent<T>, progress: CGFloat) {
     switch state {
-    case let .scrolling(pagingItem, upcomingPagingItem, oldOffset):
-      if oldOffset < 0 && offset > 0 {
+    case let .scrolling(pagingItem, upcomingPagingItem, oldProgress):
+      if oldProgress < 0 && progress > 0 {
         state = .selected(pagingItem: pagingItem)
-      } else if oldOffset > 0 && offset < 0 {
+      } else if oldProgress > 0 && progress < 0 {
         state = .selected(pagingItem: pagingItem)
-      } else if offset == 0 {
+      } else if progress == 0 {
         state = .selected(pagingItem: pagingItem)
       } else {
         state = .scrolling(
           pagingItem: pagingItem,
           upcomingPagingItem: upcomingPagingItem,
-          offset: offset)
+          progress: progress)
       }
     case let .selected(pagingItem):
-      if offset > 0 {
+      if progress > 0 {
         state = .scrolling(
           pagingItem: pagingItem,
           upcomingPagingItem: delegate?.pagingStateMachine(self,
             pagingItemAfterPagingItem: pagingItem),
-          offset: offset)
-      } else if offset < 0 {
+          progress: progress)
+      } else if progress < 0 {
         state = .scrolling(
           pagingItem: pagingItem,
           upcomingPagingItem: delegate?.pagingStateMachine(self,
             pagingItemBeforePagingItem: pagingItem),
-          offset: offset)
+          progress: progress)
       }
     }
     didChangeState?(state, event)
@@ -76,7 +76,7 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
         state = .scrolling(
           pagingItem: state.currentPagingItem,
           upcomingPagingItem: selectedPagingItem,
-          offset: 0)
+          progress: 0)
         
         didSelectPagingItem?(selectedPagingItem, direction, animated)
         didChangeState?(state, event)

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -328,7 +328,7 @@ open class PagingViewController<T: PagingItem>:
   // MARK: EMPageViewControllerDelegate
 
   open func em_pageViewController(_ pageViewController: EMPageViewController, isScrollingFrom startingViewController: UIViewController, destinationViewController: UIViewController?, progress: CGFloat) {
-    stateMachine?.fire(.scroll(offset: progress))
+    stateMachine?.fire(.scroll(progress: progress))
   }
   
   open func em_pageViewController(_ pageViewController: EMPageViewController, didFinishScrollingFrom startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {

--- a/Parchment/Enums/PagingEvent.swift
+++ b/Parchment/Enums/PagingEvent.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum PagingEvent<T: PagingItem> where T: Equatable {
-  case scroll(offset: CGFloat)
+  case scroll(progress: CGFloat)
   case select(pagingItem: T, direction: PagingDirection, animated: Bool)
   case finishScrolling
   case cancelScrolling

--- a/Parchment/Enums/PagingOptions.swift
+++ b/Parchment/Enums/PagingOptions.swift
@@ -50,6 +50,11 @@ public enum PagingMenuHorizontalAlignment {
   case center
 }
 
+public enum PagingMenuTransition {
+  case scrollAlongside
+  case animateAfter
+}
+
 public protocol PagingTheme {
   var font: UIFont { get }
   var textColor: UIColor { get }
@@ -66,6 +71,7 @@ public protocol PagingOptions {
   var menuItemSpacing: CGFloat { get }
   var menuInsets: UIEdgeInsets { get }
   var menuHorizontalAlignment: PagingMenuHorizontalAlignment { get }
+  var menuTransition: PagingMenuTransition { get }
   var selectedScrollPosition: PagingSelectedScrollPosition { get }
   var indicatorOptions: PagingIndicatorOptions { get }
   var borderOptions: PagingBorderOptions { get }
@@ -131,6 +137,10 @@ public extension PagingOptions {
   
   var selectedScrollPosition: PagingSelectedScrollPosition {
     return .preferCentered
+  }
+  
+  var menuTransition: PagingMenuTransition {
+    return .scrollAlongside
   }
   
   var theme: PagingTheme {

--- a/Parchment/Enums/PagingState.swift
+++ b/Parchment/Enums/PagingState.swift
@@ -2,14 +2,18 @@ import Foundation
 
 enum PagingState<T: PagingItem>: Equatable where T: Equatable {
   case selected(pagingItem: T)
-  case scrolling(pagingItem: T, upcomingPagingItem: T?, progress: CGFloat)
+  case scrolling(
+    pagingItem: T,
+    upcomingPagingItem: T?,
+    progress: CGFloat,
+    transition: PagingTransition?)
 }
 
 extension PagingState {
   
   var currentPagingItem: T {
     switch self {
-    case let .scrolling(pagingItem, _, _):
+    case let .scrolling(pagingItem, _, _, _):
       return pagingItem
     case let .selected(pagingItem):
       return pagingItem
@@ -18,7 +22,7 @@ extension PagingState {
   
   var upcomingPagingItem: T? {
     switch self {
-    case let .scrolling(_, upcomingPagingItem, _):
+    case let .scrolling(_, upcomingPagingItem, _, _):
       return upcomingPagingItem
     case .selected:
       return nil
@@ -27,8 +31,26 @@ extension PagingState {
   
   var progress: CGFloat {
     switch self {
-    case let .scrolling(_, _, progress):
+    case let .scrolling(_, _, progress, _):
       return progress
+    case .selected:
+      return 0
+    }
+  }
+  
+  var contentOffset: CGPoint {
+    switch self {
+    case let .scrolling(_, _, _, transition):
+      return transition?.contentOffset ?? .zero
+    case .selected:
+      return .zero
+    }
+  }
+  
+  var distance: CGFloat {
+    switch self {
+    case let .scrolling(_, _, _, transition):
+      return transition?.distance ?? 0
     case .selected:
       return 0
     }
@@ -46,11 +68,11 @@ extension PagingState {
 
 func ==<T: PagingItem>(lhs: PagingState<T>, rhs: PagingState<T>) -> Bool where T: Equatable {
   switch (lhs, rhs) {
-  case (let .scrolling(a, b, c), let .scrolling(x, y, z)):
-    if a == x && c == z {
-      if let b = b, let y = y, b == y {
+  case (let .scrolling(a, b, c, d), let .scrolling(w, x, y, z)):
+    if a == w && c == y && d == z {
+      if let b = b, let x = x, b == x {
         return true
-      } else if b == nil && y == nil {
+      } else if b == nil && x == nil {
         return true
       }
     }

--- a/Parchment/Enums/PagingState.swift
+++ b/Parchment/Enums/PagingState.swift
@@ -2,7 +2,7 @@ import Foundation
 
 enum PagingState<T: PagingItem>: Equatable where T: Equatable {
   case selected(pagingItem: T)
-  case scrolling(pagingItem: T, upcomingPagingItem: T?, offset: CGFloat)
+  case scrolling(pagingItem: T, upcomingPagingItem: T?, progress: CGFloat)
 }
 
 extension PagingState {
@@ -25,17 +25,17 @@ extension PagingState {
     }
   }
   
-  var offset: CGFloat {
+  var progress: CGFloat {
     switch self {
-    case let .scrolling(_, _, offset):
-      return offset
+    case let .scrolling(_, _, progress):
+      return progress
     case .selected:
       return 0
     }
   }
   
   var visuallySelectedPagingItem: T {
-    if fabs(offset) > 0.5 {
+    if fabs(progress) > 0.5 {
       return upcomingPagingItem ?? currentPagingItem
     } else {
       return currentPagingItem

--- a/Parchment/Structs/PagingTransition.swift
+++ b/Parchment/Structs/PagingTransition.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+struct PagingTransition : Equatable {
+  let contentOffset: CGPoint
+  let distance: CGFloat
+}
+
+func ==(lhs: PagingTransition, rhs: PagingTransition) -> Bool {
+  return (lhs.contentOffset == rhs.contentOffset && lhs.distance == rhs.distance)
+}

--- a/ParchmentTests/PagingStateMachineSpec.swift
+++ b/ParchmentTests/PagingStateMachineSpec.swift
@@ -35,6 +35,12 @@ private class Delegate: PagingStateMachineDelegate {
   
   func pagingStateMachine<T>(
     _ pagingStateMachine: PagingStateMachine<T>,
+    transitionFrom: T, to: T?) -> PagingTransition {
+    return PagingTransition(contentOffset: .zero, distance: 0)
+  }
+  
+  func pagingStateMachine<T>(
+    _ pagingStateMachine: PagingStateMachine<T>,
     pagingItemBeforePagingItem pagingItem: T) -> T? {
     let item = pagingItem as! Item
     return Item(index: item.index - 1) as? T
@@ -57,6 +63,7 @@ class PagingStateMachineSpec: QuickSpec {
       
       var stateMachineDelegate: Delegate!
       var stateMachine: PagingStateMachine<Item>!
+      let defaultTransition = PagingTransition(contentOffset: .zero, distance: 0)
       
       beforeEach {
         let state: PagingState = .selected(pagingItem: Item(index: 0))
@@ -80,7 +87,8 @@ class PagingStateMachineSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              progress: 0.5)
+              progress: 0.5,
+              transition: defaultTransition)
             stateMachine = PagingStateMachine(initialState: state)
           }
           
@@ -102,7 +110,8 @@ class PagingStateMachineSpec: QuickSpec {
               let state: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: nil,
-                progress: 0.5)
+                progress: 0.5,
+                transition: defaultTransition)
               stateMachine = PagingStateMachine(initialState: state)
             }
             
@@ -132,7 +141,8 @@ class PagingStateMachineSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              progress: 0.5)
+              progress: 0.5,
+              transition: defaultTransition)
             stateMachine = PagingStateMachine(initialState: state)
           }
           
@@ -155,7 +165,8 @@ class PagingStateMachineSpec: QuickSpec {
               let state: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: nil,
-                progress: 0)
+                progress: 0,
+                transition: defaultTransition)
               
               stateMachine = PagingStateMachine(initialState: state)
               
@@ -282,7 +293,8 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: 0.1)
+                progress: 0.1,
+                transition: defaultTransition)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: -0.1))
               expect(stateMachine.state).to(beSelected())
@@ -295,7 +307,8 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: -0.1)
+                progress: -0.1,
+                transition: defaultTransition)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state).to(beSelected())
@@ -309,7 +322,8 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: 0.5)
+                progress: 0.5,
+                transition: defaultTransition)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: 0))
               expect(stateMachine.state).to(beSelected())
@@ -319,7 +333,8 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: 0)
+                progress: 0,
+                transition: defaultTransition)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: 1)))

--- a/ParchmentTests/PagingStateMachineSpec.swift
+++ b/ParchmentTests/PagingStateMachineSpec.swift
@@ -80,7 +80,7 @@ class PagingStateMachineSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              offset: 0.5)
+              progress: 0.5)
             stateMachine = PagingStateMachine(initialState: state)
           }
           
@@ -102,7 +102,7 @@ class PagingStateMachineSpec: QuickSpec {
               let state: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: nil,
-                offset: 0.5)
+                progress: 0.5)
               stateMachine = PagingStateMachine(initialState: state)
             }
             
@@ -132,7 +132,7 @@ class PagingStateMachineSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              offset: 0.5)
+              progress: 0.5)
             stateMachine = PagingStateMachine(initialState: state)
           }
           
@@ -155,7 +155,7 @@ class PagingStateMachineSpec: QuickSpec {
               let state: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: nil,
-                offset: 0)
+                progress: 0)
               
               stateMachine = PagingStateMachine(initialState: state)
               
@@ -178,12 +178,12 @@ class PagingStateMachineSpec: QuickSpec {
               expect(stateMachine.state).to(beScrolling())
             }
             
-            it("sets to offset to zero") {
+            it("sets to progress to zero") {
               stateMachine.fire(.select(
                 pagingItem: Item(index: 1),
                 direction: .none,
                 animated: false))
-              expect(stateMachine.state.offset).to(equal(0))
+              expect(stateMachine.state.progress).to(equal(0))
             }
             
             it("uses the state's current paging item") {
@@ -266,62 +266,62 @@ class PagingStateMachineSpec: QuickSpec {
       describe("scroll event") {
         
         it("uses the state's current paging item") {
-          stateMachine.fire(.scroll(offset: 0))
+          stateMachine.fire(.scroll(progress: 0))
           expect(stateMachine.state.currentPagingItem).to(equal(Item(index: 0)))
         }
         
-        it("sets the new offset") {
-          stateMachine.fire(.scroll(offset: 0.5))
-          expect(stateMachine.state.offset).to(equal(0.5))
+        it("sets the new progress") {
+          stateMachine.fire(.scroll(progress: 0.5))
+          expect(stateMachine.state.progress).to(equal(0.5))
         }
         
         describe("is in the scrolling state") {
           
-          describe("the sign of the offset value changed to negative") {
+          describe("the sign of the progress value changed to negative") {
             it("resets the scrolling state") {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                offset: 0.1)
+                progress: 0.1)
               stateMachine = PagingStateMachine(initialState: initialState)
-              stateMachine.fire(.scroll(offset: -0.1))
+              stateMachine.fire(.scroll(progress: -0.1))
               expect(stateMachine.state).to(beSelected())
             }
           }
           
-          describe("the sign of the offset value changed to postive") {
+          describe("the sign of the progress value changed to postive") {
             
-            it("resets the scrolling state if the offset changes from negative to positive") {
+            it("resets the scrolling state if the progress changes from negative to positive") {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                offset: -0.1)
+                progress: -0.1)
               stateMachine = PagingStateMachine(initialState: initialState)
-              stateMachine.fire(.scroll(offset: 0.1))
+              stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state).to(beSelected())
             }
             
           }
           
-          describe("the sign of the offset didn't change") {
+          describe("the sign of the progress didn't change") {
             
-            it("resets the scrolling state if the offset is zero") {
+            it("resets the scrolling state if the progress is zero") {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                offset: 0.5)
+                progress: 0.5)
               stateMachine = PagingStateMachine(initialState: initialState)
-              stateMachine.fire(.scroll(offset: 0))
+              stateMachine.fire(.scroll(progress: 0))
               expect(stateMachine.state).to(beSelected())
             }
             
-            it("uses the state's upcoming paging item if the offset is not zero") {
+            it("uses the state's upcoming paging item if the progress is not zero") {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                offset: 0)
+                progress: 0)
               stateMachine = PagingStateMachine(initialState: initialState)
-              stateMachine.fire(.scroll(offset: 0.1))
+              stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: 1)))
             }
             
@@ -331,15 +331,15 @@ class PagingStateMachineSpec: QuickSpec {
         
         describe("is in the selected state") {
           
-          it("it does not update the state if the offset is zero") {
-            stateMachine.fire(.scroll(offset: 0))
+          it("it does not update the state if the progress is zero") {
+            stateMachine.fire(.scroll(progress: 0))
             let expectedState: PagingState = .selected(pagingItem: Item(index: 0))
             expect(stateMachine.state).to(equal(expectedState))
           }
           
           describe("has no delegate") {
             it("sets the upcoming paging item to nil") {
-              stateMachine.fire(.scroll(offset: 0.1))
+              stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state.upcomingPagingItem).to(beNil())
             }
           }
@@ -350,14 +350,14 @@ class PagingStateMachineSpec: QuickSpec {
               stateMachine.delegate = stateMachineDelegate
             }
             
-            it("uses the leading paging item if the offset is negative") {
-              stateMachine.fire(.scroll(offset: -0.1))
+            it("uses the leading paging item if the progress is negative") {
+              stateMachine.fire(.scroll(progress: -0.1))
               expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: -1)))
             }
             
             
-            it("uses the trailing paging item if the offset is positive") {
-              stateMachine.fire(.scroll(offset: 0.1))
+            it("uses the trailing paging item if the progress is positive") {
+              stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: 1)))
             }
             

--- a/ParchmentTests/PagingStateSpec.swift
+++ b/ParchmentTests/PagingStateSpec.swift
@@ -23,16 +23,16 @@ class PagingStateSpec: QuickSpec {
           let state: PagingState = .scrolling(
             pagingItem: Item(index: 0),
             upcomingPagingItem: Item(index: 1),
-            offset: 0)
+            progress: 0)
           expect(state.currentPagingItem).to(equal(Item(index: 0)))
         }
         
-        it("returns the correct offset") {
+        it("returns the correct progress") {
           let state: PagingState = .scrolling(
             pagingItem: Item(index: 0),
             upcomingPagingItem: Item(index: 1),
-            offset: 0.5)
-          expect(state.offset).to(equal(0.5))
+            progress: 0.5)
+          expect(state.progress).to(equal(0.5))
         }
         
         describe("has an upcoming paging item") {
@@ -41,28 +41,28 @@ class PagingStateSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              offset: 0)
+              progress: 0)
             expect(state.upcomingPagingItem).to(equal(Item(index: 1)))
           }
           
           describe("visuallySelectedPagingItem") {
           
-            describe("offset is larger then 0.5") {
+            describe("progress is larger then 0.5") {
               it("returns the upcoming paging item as the visually selected item") {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: Item(index: 1),
-                  offset: 0.6)
+                  progress: 0.6)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 1)))
               }
             }
             
-            describe("offset is smaller then 0.5") {
+            describe("progress is smaller then 0.5") {
               it("returns the current paging item as the visually selected item") {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: Item(index: 1),
-                  offset: 0.3)
+                  progress: 0.3)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }
@@ -77,28 +77,28 @@ class PagingStateSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: nil,
-              offset: 0)
+              progress: 0)
             expect(state.upcomingPagingItem).to(beNil())
           }
           
           describe("visuallySelectedPagingItem") {
             
-            describe("offset is larger then 0.5") {
+            describe("progress is larger then 0.5") {
               it("returns the current paging item as the visually selected item") {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: nil,
-                  offset: 0.6)
+                  progress: 0.6)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }
             
-            describe("offset is smaller then 0.5") {
+            describe("progress is smaller then 0.5") {
               it("returns the current paging item as the visually selected item") {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: nil,
-                  offset: 0.3)
+                  progress: 0.3)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }
@@ -120,8 +120,8 @@ class PagingStateSpec: QuickSpec {
           expect(state.upcomingPagingItem).to(beNil())
         }
         
-        it("returns zero for the offset") {
-          expect(state.offset).to(equal(0))
+        it("returns zero for the progress") {
+          expect(state.progress).to(equal(0))
         }
         
         it("returns the current paging item as the visually selected item") {

--- a/ParchmentTests/PagingStateSpec.swift
+++ b/ParchmentTests/PagingStateSpec.swift
@@ -17,13 +17,16 @@ class PagingStateSpec: QuickSpec {
     
     describe("PagingState") {
       
+      let defaultTransition = PagingTransition(contentOffset: .zero, distance: 0)
+      
       describe("Scrolling") {
         
         it("returns the current paging item") {
           let state: PagingState = .scrolling(
             pagingItem: Item(index: 0),
             upcomingPagingItem: Item(index: 1),
-            progress: 0)
+            progress: 0,
+            transition: defaultTransition)
           expect(state.currentPagingItem).to(equal(Item(index: 0)))
         }
         
@@ -31,7 +34,8 @@ class PagingStateSpec: QuickSpec {
           let state: PagingState = .scrolling(
             pagingItem: Item(index: 0),
             upcomingPagingItem: Item(index: 1),
-            progress: 0.5)
+            progress: 0.5,
+            transition: defaultTransition)
           expect(state.progress).to(equal(0.5))
         }
         
@@ -41,7 +45,8 @@ class PagingStateSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              progress: 0)
+              progress: 0,
+              transition: defaultTransition)
             expect(state.upcomingPagingItem).to(equal(Item(index: 1)))
           }
           
@@ -52,7 +57,8 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: Item(index: 1),
-                  progress: 0.6)
+                  progress: 0.6,
+                  transition: defaultTransition)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 1)))
               }
             }
@@ -62,7 +68,8 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: Item(index: 1),
-                  progress: 0.3)
+                  progress: 0.3,
+                  transition: defaultTransition)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }
@@ -77,7 +84,8 @@ class PagingStateSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: nil,
-              progress: 0)
+              progress: 0,
+              transition: defaultTransition)
             expect(state.upcomingPagingItem).to(beNil())
           }
           
@@ -88,7 +96,8 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: nil,
-                  progress: 0.6)
+                  progress: 0.6,
+                  transition: defaultTransition)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }
@@ -98,7 +107,8 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: nil,
-                  progress: 0.3)
+                  progress: 0.3,
+                  transition: defaultTransition)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }

--- a/README.md
+++ b/README.md
@@ -187,9 +187,7 @@ The insets around all of the menu items.
 
 _Default: `UIEdgeInsets()`_
 
-#### `menuAlignment`
-  
-
+#### `menuHorizontalAlignment`
 
 ```Swift
 public enum PagingMenuHorizontalAlignment {
@@ -203,6 +201,23 @@ public enum PagingMenuHorizontalAlignment {
 ```
 
 _Default: `.Default`_
+
+#### `menuTransition`
+
+Determine the transition behaviour of menu items while scrolling the content.
+
+```Swift
+public enum PagingMenuTransition {
+  // Update scroll offset based on how much the content has
+  // scrolled. Makes the menu items transition smoothly as you scroll.
+  case scrollAlongside
+  
+  // Animate the menu item position after a transition has completed.
+  case animateAfter
+}
+```
+
+Default: .scrollAlongside
 
 #### `PagingSelectedScrollPosition`
 


### PR DESCRIPTION
Updates the scroll offset based on how much the content has scrolled.
This makes the menu items transition smoothly as you scroll. The old
behaviour is available as an option on the `menuTransition` property.

Getting the menu items to scroll alongside the content requires us to
calculate the distance between the current and upcoming paging item,
and then update the content offset based on the transition progress. We
also need to keep track of the initial content offset, so we create a
new `PagingTransition` struct that can store all this data.

Fixes: #15 