### PR TITLE
Move collection view above paging view

### DIFF
--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -22,8 +22,8 @@ open class PagingView: UIView {
   }
   
   open func configure() {
-    addSubview(collectionView)
     addSubview(pageView)
+    addSubview(collectionView)
     setupConstraints()
   }
   


### PR DESCRIPTION
With the default behavior this doesn't really make any changes, but
when customizing the constraints it's more likely that you want the
menu items to appear above the paging view.