### PR TITLE
Allow selectPagingItem to be called before viewDidAppear

### DIFF
--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -57,10 +57,7 @@ class ViewController: UIViewController {
     
     // Set our custom data source
     pagingViewController.dataSource = self
-  }
-  
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
+    
     // Set the current date as the selected paging item
     pagingViewController.selectPagingItem(CalendarItem(date: Date()))
   }

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -1603,10 +1603,10 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = StoryboardExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.martinrechsteiner.StoryboardExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1623,10 +1623,10 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = StoryboardExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.martinrechsteiner.StoryboardExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1716,6 +1716,7 @@
 				95B3010D1E59E43900B95D02 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Parchment/Classes/FixedPagingViewController.swift
+++ b/Parchment/Classes/FixedPagingViewController.swift
@@ -24,17 +24,13 @@ open class FixedPagingViewController: PagingViewController<ViewControllerItem> {
     super.init(options: options)
     dataSource = self
     
+    if let item = items.first {
+      selectPagingItem(item)
+    }
   }
 
   required public init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
-  }
-  
-  open override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
-    if let item = items.first {
-      selectPagingItem(item)
-    }
   }
   
 }

--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -73,10 +73,6 @@ class ViewController: UIViewController {
     
     // Set our custom data source.
     pagingViewController.dataSource = dataSource
-  }
-  
-  override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
     
     // Set the first item as the selected paging item.
     pagingViewController.selectPagingItem(dataSource.items.first!)


### PR DESCRIPTION
Previously, selectPagingItem had to be called before viewDidAppear in
order to show the menu items with the correct item selected. This
update fixes this issue.