### PR TITLE
Fix calculation for transition distance

### DIFF
--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -29,10 +29,6 @@ struct CalendarPagingTheme: PagingTheme {
 struct CalendarPagingOptions: PagingOptions {
   let menuItemClass: PagingCell.Type = CalendarPagingCell.self
   let menuItemSize: PagingMenuItemSize = .fixed(width: 48, height: 58)
-  let indicatorOptions: PagingIndicatorOptions = .visible(height: 2,
-                                                          zIndex: Int.max,
-                                                          spacing: UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8),
-                                                          insets: UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8))
   let theme: PagingTheme = CalendarPagingTheme()
 }
 

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -820,12 +820,12 @@
 				TargetAttributes = {
 					3E2AAD041CA81D480044AAA5 = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = C48GZ8PUTA;
+						DevelopmentTeam = G4TGN24VA2;
 						LastSwiftMigration = 0810;
 					};
 					3E2AAD321CA86C690044AAA5 = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = C48GZ8PUTA;
+						DevelopmentTeam = G4TGN24VA2;
 						LastSwiftMigration = 0810;
 					};
 					3E504EC31C7465B000AE1CE3 = {
@@ -835,7 +835,7 @@
 					};
 					3E5E93EF1CE8BA1E000762A1 = {
 						CreatedOnToolsVersion = 7.3;
-						DevelopmentTeam = C48GZ8PUTA;
+						DevelopmentTeam = G4TGN24VA2;
 						LastSwiftMigration = 0810;
 					};
 					3EA04A4A1C53BFE40054E5E0 = {
@@ -845,12 +845,12 @@
 					};
 					3EA04A591C53BFF40054E5E0 = {
 						CreatedOnToolsVersion = 7.2;
-						DevelopmentTeam = C48GZ8PUTA;
+						DevelopmentTeam = G4TGN24VA2;
 						LastSwiftMigration = 0810;
 					};
 					9597F29B1E394482003FD289 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = C48GZ8PUTA;
+						DevelopmentTeam = G4TGN24VA2;
 						ProvisioningStyle = Automatic;
 					};
 					95B300FC1E59E43800B95D02 = {
@@ -1253,6 +1253,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = CalendarExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1268,6 +1269,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = CalendarExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1283,6 +1285,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = DelegateExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1298,6 +1301,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = DelegateExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1345,6 +1349,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = UnplashExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1360,6 +1365,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = UnplashExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1524,6 +1530,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1543,6 +1550,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1565,7 +1573,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = C48GZ8PUTA;
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = IconsExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1585,7 +1593,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = C48GZ8PUTA;
+				DEVELOPMENT_TEAM = G4TGN24VA2;
 				INFOPLIST_FILE = IconsExample/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		95B3010F1E59E70D00B95D02 /* Parchment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; };
 		95B301101E59E70D00B95D02 /* Parchment.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		95B301151E59E9BB00B95D02 /* UIView+constraints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B301141E59E9BB00B95D02 /* UIView+constraints.swift */; };
+		95B301171E59FCD500B95D02 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B301161E59FCD500B95D02 /* UIEdgeInsets.swift */; };
+		95B301191E59FD1600B95D02 /* UIScrollView+near.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B301181E59FD1600B95D02 /* UIScrollView+near.swift */; };
 		95F2CCA61E395762003C973E /* Parchment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; };
 		95F2CCA71E395762003C973E /* Parchment.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -341,6 +343,8 @@
 		95B301091E59E43800B95D02 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		95B3010B1E59E43800B95D02 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		95B301141E59E9BB00B95D02 /* UIView+constraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+constraints.swift"; sourceTree = "<group>"; };
+		95B301161E59FCD500B95D02 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
+		95B301181E59FD1600B95D02 /* UIScrollView+near.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScrollView+near.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -583,6 +587,8 @@
 			children = (
 				3E2AAD271CA831AB0044AAA5 /* UIView+constraints.swift */,
 				9597F2941E3903F4003FD289 /* UIColor+interpolation.swift */,
+				95B301161E59FCD500B95D02 /* UIEdgeInsets.swift */,
+				95B301181E59FD1600B95D02 /* UIScrollView+near.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1049,6 +1055,7 @@
 				3E4090831C88BBCF00800E22 /* Reusable.swift in Sources */,
 				3E2AAD281CA831AB0044AAA5 /* UIView+constraints.swift in Sources */,
 				3E49C7251C8F5C13006269DD /* PagingBorderView.swift in Sources */,
+				95B301191E59FD1600B95D02 /* UIScrollView+near.swift in Sources */,
 				3E40909A1C88BCC900800E22 /* PagingDirection.swift in Sources */,
 				3ED1C8D81CC1554E00B46885 /* PagingItemPresentable.swift in Sources */,
 				3E49C7291C8F5C13006269DD /* PagingView.swift in Sources */,
@@ -1062,6 +1069,7 @@
 				3E4090AE1C88BDD100800E22 /* PagingBorderLayoutAttributes.swift in Sources */,
 				3E4283FC1C99CF9000032D95 /* PagingDataStructure.swift in Sources */,
 				3E49C7281C8F5C13006269DD /* PagingIndicatorView.swift in Sources */,
+				95B301171E59FCD500B95D02 /* UIEdgeInsets.swift in Sources */,
 				3E49C7261C8F5C13006269DD /* PagingCell.swift in Sources */,
 				3E49C72E1C8F5CCE006269DD /* PagingCellViewModel.swift in Sources */,
 				3E562ACE1CE7CD8C007623B3 /* PagingTitleCell.swift in Sources */,

--- a/Parchment/Extensions/UIEdgeInsets.swift
+++ b/Parchment/Extensions/UIEdgeInsets.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIEdgeInsets {
+  
+  var horizontal: CGFloat {
+    return left + right
+  }
+  
+  var vertical: CGFloat {
+    return top + bottom
+  }
+  
+}

--- a/Parchment/Extensions/UIScrollView+near.swift
+++ b/Parchment/Extensions/UIScrollView+near.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+enum Edge {
+  case left, right, top, bottom
+}
+
+extension UIScrollView {
+  
+  func near(edge: Edge, clearance: CGFloat = 0) -> Bool {
+    switch edge {
+    case .left:
+      return contentOffset.x + contentInset.left - clearance <= 0
+    case .right:
+      return (contentOffset.x + bounds.width + clearance) >= contentSize.width
+    case .top:
+      return contentOffset.y + contentInset.top - clearance <= 0
+    case .bottom:
+      return (contentOffset.y + bounds.height + clearance) >= contentSize.height
+    }
+  }
+  
+}

--- a/StoryboardExample/Base.lproj/Main.storyboard
+++ b/StoryboardExample/Base.lproj/Main.storyboard
@@ -12,9 +12,8 @@
         <!--Navigation Controller-->
         <scene sceneID="iFJ-Da-Xjx">
             <objects>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="UoW-K9-Ezy" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <navigationController id="5ZW-Jx-LCp" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" barStyle="black" id="3Im-Xt-q8V">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="3Im-Xt-q8V">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="0.01176470588" green="0.49019607840000001" blue="0.91372549020000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -23,6 +22,7 @@
                         <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="SjN-qI-N0d"/>
                     </connections>
                 </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="UoW-K9-Ezy" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-297" y="74"/>
         </scene>
@@ -34,7 +34,7 @@
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" misplaced="YES" id="8bC-Xf-vdC">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -58,8 +58,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Pg-WS-nr3">
-                                <rect key="frame" x="154.5" y="317" width="66.5" height="33.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="First" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0Pg-WS-nr3">
+                                <rect key="frame" x="162" y="317" width="51.5" height="33.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" red="0.49803921579999999" green="0.49803921579999999" blue="0.49803921579999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -88,8 +88,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VTe-uF-1Q8">
-                                <rect key="frame" x="155" y="317" width="66.5" height="33.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Second" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VTe-uF-1Q8">
+                                <rect key="frame" x="141.5" y="317" width="93.5" height="33.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" red="0.49803921579999999" green="0.49803921579999999" blue="0.49803921579999999" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>

--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -40,7 +40,8 @@ struct ImagePagingOptions: PagingOptions {
   let indicatorOptions: PagingIndicatorOptions = .visible(
     height: 1,
     zIndex: Int.max,
-    insets: UIEdgeInsets())
+    spacing: UIEdgeInsets.zero,
+    insets: UIEdgeInsets.zero)
   
   let borderOptions: PagingBorderOptions = .visible(
     height: 1,


### PR DESCRIPTION
When swiping to pages on the left or right edge we previously just took
the min and max value of the content offset to make sure it didn’t move
too far. This caused the transition to suddenly stop instead of
smoothly transitioning to the correct place.

This updated checks if the new content offset will be near any of the
edges and calculate how much it will overshoot. Then we can just
subtract that value from the original distance to get the correct
transition.