### PR TITLE
Fix issue with transition distance

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -408,9 +408,9 @@ open class PagingViewController<T: PagingItem>:
     let upcomingCell = collectionView(collectionView, cellForItemAt: upcomingIndexPath)
     var distance = self.distance(from: currentCell, to: upcomingCell)
    
-    if collectionView.near(edge: .left, clearance: -distance) {
+    if collectionView.near(edge: .left, clearance: -distance) && distance < 0 {
       distance = -(collectionView.contentOffset.x + collectionView.contentInset.left)
-    } else if collectionView.near(edge: .right, clearance: distance) {
+    } else if collectionView.near(edge: .right, clearance: distance) && distance > 0 {
       distance = collectionView.contentSize.width - (collectionView.contentOffset.x + collectionView.bounds.width)
     }
     


### PR DESCRIPTION
The fix for the transition distance in #33 had an issue with selecting
an item on the opposite side while being near an edge. We only want to
subtract the overshoot when we’re moving towards an edge.