### PR TITLE
Fix issue with selecting paging item

### DIFF
--- a/Parchment/Classes/EMPageViewController.swift
+++ b/Parchment/Classes/EMPageViewController.swift
@@ -198,6 +198,10 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
    */
   open func selectViewController(_ viewController: UIViewController, direction: EMPageViewControllerNavigationDirection, animated: Bool, completion: ((_ transitionSuccessful: Bool) -> Void)?) {
     
+    if viewController == self.selectedViewController {
+      return
+    }
+    
     if (direction == .forward) {
       self.afterViewController = viewController
       self.layoutViews()


### PR DESCRIPTION
Adding support for selecting paging items before viewDidAppear (#32)
introduced a bug when navigating back and fourth to the paging view,
for instance when using a tab bar.

EMPageViewController does not support calling selectViewController with
the same view controller that is currently selected. When doing that it
selects the next view controller and causes corrupted menu items. To
fix this we just return if you select the same view controller twice.