### PR TITLE
Remove view controller selection in viewDidAppear

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -84,39 +84,31 @@ open class PagingViewController<T: PagingItem>:
       let state: PagingState = .selected(pagingItem: pagingItem)
       stateMachine = PagingStateMachine(initialState: state)
       collectionViewLayout.state = state
+
+      selectViewController(
+        state.currentPagingItem,
+        direction: .none,
+        animated: false)
       
       if isViewLoaded && view.window != nil {
-        
         generateItems(around: state.currentPagingItem)
-        
         collectionView.selectItem(
           at: dataStructure.indexPathForPagingItem(state.currentPagingItem),
           animated: false,
           scrollPosition: options.scrollPosition)
-        
-        selectViewController(
-          state.currentPagingItem,
-          direction: .none,
-          animated: false)
       }
     }
   }
-  
+    
   open override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)
     guard let state = stateMachine?.state else { return }
     
     generateItems(around: state.currentPagingItem)
-  
     collectionView.selectItem(
       at: dataStructure.indexPathForPagingItem(state.currentPagingItem),
       animated: false,
       scrollPosition: options.scrollPosition)
-
-    selectViewController(
-      state.currentPagingItem,
-      direction: .none,
-      animated: false)
   }
   
   open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
When viewDidAppear is called it triggers viewControllerForPagingItem
data source method. This can potentially create a new instance of the
selected view controller each time viewDidAppear is called.

Calling selectViewController in viewDidAppear was added to allow
selectPagingItem to be called before viewDidAppear (#32). Turns out
it’s sufficient to only call selectViewController when calling
selectPagingItem.