### PR TITLE
Fix selectPagingItem

### DIFF
--- a/Parchment/Classes/EMPageViewController.swift
+++ b/Parchment/Classes/EMPageViewController.swift
@@ -84,7 +84,7 @@ import UIKit
      - parameter destinationViewController: The view controller being scrolled to where the transition should end
      - parameter progress: The progress of the transition, where 0 is a neutral scroll position, >= 1 is a complete transition to the right view controller in a horizontal orientation, or the below view controller in a vertical orientation, and <= -1 is a complete transition to the left view controller in a horizontal orientation, or the above view controller in a vertical orientation. Values may be greater than 1 or less than -1 if bouncing is enabled and the scroll velocity is quick enough.
      */
-    @objc optional func em_pageViewController(_ pageViewController: EMPageViewController, isScrollingFrom startingViewController: UIViewController, destinationViewController:UIViewController?, progress: CGFloat)
+    @objc optional func em_pageViewController(_ pageViewController: EMPageViewController, isScrollingFrom startingViewController: UIViewController, destinationViewController: UIViewController?, progress: CGFloat)
     
     /**
      Called after a page transition attempt has completed.

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -68,6 +68,13 @@ open class PagingViewController<T: PagingItem>:
     collectionView.registerReusableCell(options.menuItemClass)
     
     setupGestureRecognizers()
+    
+    if let state = stateMachine?.state {
+      selectViewController(
+        state.currentPagingItem,
+        direction: .none,
+        animated: false)
+    }
   }
   
   open func selectPagingItem(_ pagingItem: T, animated: Bool = false) {
@@ -84,18 +91,20 @@ open class PagingViewController<T: PagingItem>:
       let state: PagingState = .selected(pagingItem: pagingItem)
       stateMachine = PagingStateMachine(initialState: state)
       collectionViewLayout.state = state
-
-      selectViewController(
-        state.currentPagingItem,
-        direction: .none,
-        animated: false)
       
-      if isViewLoaded && view.window != nil {
-        generateItems(around: state.currentPagingItem)
-        collectionView.selectItem(
-          at: dataStructure.indexPathForPagingItem(state.currentPagingItem),
-          animated: false,
-          scrollPosition: options.scrollPosition)
+      if isViewLoaded {
+        selectViewController(
+          state.currentPagingItem,
+          direction: .none,
+          animated: false)
+        
+        if view.window != nil {
+          generateItems(around: state.currentPagingItem)
+          collectionView.selectItem(
+            at: dataStructure.indexPathForPagingItem(state.currentPagingItem),
+            animated: false,
+            scrollPosition: options.scrollPosition)
+        }
       }
     }
   }


### PR DESCRIPTION
When calling selectPagingItem before viewDidLoad the
EMPageViewControllerDelegate was not set, which made it impossible to
swipe to the next page.