### PR TITLE
Fix background color on header view

### DIFF
--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -22,6 +22,7 @@ open class PagingView: UIView {
   }
   
   open func configure() {
+    collectionView.backgroundColor = options.theme.headerBackgroundColor
     addSubview(pageView)
     addSubview(collectionView)
     setupConstraints()


### PR DESCRIPTION
Turns out the background color options on the PagingTheme was not
applied to the menu header view.