### PR TITLE
Fix issue with delayed rendering

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -108,11 +108,12 @@ open class PagingViewController<T: PagingItem>:
       }
     }
   }
-    
-  open override func viewDidAppear(_ animated: Bool) {
-    super.viewDidAppear(animated)
+  
+  open override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
     guard let state = stateMachine?.state else { return }
     
+    view.layoutIfNeeded()
     generateItems(around: state.currentPagingItem)
     collectionView.selectItem(
       at: dataStructure.indexPathForPagingItem(state.currentPagingItem),


### PR DESCRIPTION
Generating the menu items in viewDidAppear is too late as it causes
the items to appear with a slight delay. Calling layoutIfNeeded in
viewWillAppear means we will get the correct frame before rendering.