### PR TITLE
Add delegate for FixedPagingViewController

### DIFF
--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		3EF3C1E31CA0870E00CDFE26 /* FixedPagingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF3C1E21CA0870E00CDFE26 /* FixedPagingViewController.swift */; };
 		3EFEFBF71C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift */; };
 		952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952D802E1E37CC09003DCB18 /* PagingTransition.swift */; };
+		955F23491EBA733B005F45E6 /* ViewControllerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955F23481EBA733B005F45E6 /* ViewControllerItem.swift */; };
 		957F14091E35583500E562F8 /* PagingCellLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */; };
 		9597F2951E3903F4003FD289 /* UIColor+interpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597F2941E3903F4003FD289 /* UIColor+interpolation.swift */; };
 		9597F2971E390519003FD289 /* UIColor+interpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597F2961E390519003FD289 /* UIColor+interpolation.swift */; };
@@ -321,6 +322,7 @@
 		3EF3C1E21CA0870E00CDFE26 /* FixedPagingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FixedPagingViewController.swift; sourceTree = "<group>"; };
 		3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingIndicatorLayoutAttributesSpec.swift; sourceTree = "<group>"; };
 		952D802E1E37CC09003DCB18 /* PagingTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingTransition.swift; sourceTree = "<group>"; };
+		955F23481EBA733B005F45E6 /* ViewControllerItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerItem.swift; sourceTree = "<group>"; };
 		957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingCellLayoutAttributes.swift; sourceTree = "<group>"; };
 		9597F2941E3903F4003FD289 /* UIColor+interpolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+interpolation.swift"; sourceTree = "<group>"; };
 		9597F2961E390519003FD289 /* UIColor+interpolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+interpolation.swift"; sourceTree = "<group>"; };
@@ -467,6 +469,7 @@
 				3E4090A11C88BD0A00800E22 /* PagingIndicatorMetric.swift */,
 				3E4283FB1C99CF9000032D95 /* PagingDataStructure.swift */,
 				952D802E1E37CC09003DCB18 /* PagingTransition.swift */,
+				955F23481EBA733B005F45E6 /* ViewControllerItem.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -1043,6 +1046,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3EF3C1E31CA0870E00CDFE26 /* FixedPagingViewController.swift in Sources */,
+				955F23491EBA733B005F45E6 /* ViewControllerItem.swift in Sources */,
 				3E2AAD2E1CA86A320044AAA5 /* PagingViewControllerDelegate.swift in Sources */,
 				3E4090821C88BBCF00800E22 /* ArithmeticType.swift in Sources */,
 				3EADD99F1CC65C4D003171CF /* EMPageViewController.swift in Sources */,

--- a/Parchment/Classes/FixedPagingViewController.swift
+++ b/Parchment/Classes/FixedPagingViewController.swift
@@ -1,23 +1,14 @@
 import UIKit
 
-public struct ViewControllerItem: PagingTitleItem, Equatable {
-  
-  public let viewController: UIViewController
-  public let title: String
-  
-  init(viewController: UIViewController) {
-    self.viewController = viewController
-    self.title = viewController.title ?? ""
-  }
-}
-
-public func ==(lhs: ViewControllerItem, rhs: ViewControllerItem) -> Bool {
-  return lhs.viewController == rhs.viewController
+public protocol FixedPagingViewControllerDelegate : class {
+  func fixedPagingViewController(fixedPagingViewController: FixedPagingViewController, willScrollToItem: ViewControllerItem, atIndex index: Int)
+  func fixedPagingViewController(fixedPagingViewController: FixedPagingViewController, didScrollToItem: ViewControllerItem, atIndex index: Int)
 }
 
 open class FixedPagingViewController: PagingViewController<ViewControllerItem> {
   
-  let items: [ViewControllerItem]
+  open let items: [ViewControllerItem]
+  open weak var itemDelegate: FixedPagingViewControllerDelegate?
   
   public init(viewControllers: [UIViewController], options: PagingOptions = DefaultPagingOptions()) {
     items = viewControllers.map { ViewControllerItem(viewController: $0) }
@@ -31,6 +22,28 @@ open class FixedPagingViewController: PagingViewController<ViewControllerItem> {
 
   required public init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: EMPageViewControllerDelegate
+  
+  open override func em_pageViewController(_ pageViewController: EMPageViewController, didFinishScrollingFrom startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {
+    super.em_pageViewController(pageViewController, didFinishScrollingFrom: startingViewController, destinationViewController: destinationViewController, transitionSuccessful: transitionSuccessful)
+    
+    if let index = items.index(where: { $0.viewController == destinationViewController }) {
+      itemDelegate?.fixedPagingViewController(
+        fixedPagingViewController: self,
+        didScrollToItem: items[index],
+        atIndex: index)
+    }
+  }
+  
+  public func em_pageViewController(_ pageViewController: EMPageViewController, willStartScrollingFrom startingViewController: UIViewController, destinationViewController: UIViewController) {
+    if let index = items.index(where: { $0.viewController == destinationViewController }) {
+      itemDelegate?.fixedPagingViewController(
+        fixedPagingViewController: self,
+        willScrollToItem: items[index],
+        atIndex: index)
+    }
   }
   
 }

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -14,7 +14,7 @@ open class PagingViewController<T: PagingItem>:
   open weak var dataSource: PagingViewControllerDataSource?
   fileprivate var dataStructure: PagingDataStructure<T>
   
-  fileprivate var stateMachine: PagingStateMachine<T>? {
+  internal var stateMachine: PagingStateMachine<T>? {
     didSet {
       handleStateMachineUpdate()
     }

--- a/Parchment/Structs/ViewControllerItem.swift
+++ b/Parchment/Structs/ViewControllerItem.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+public struct ViewControllerItem: PagingTitleItem, Equatable {
+  
+  public let viewController: UIViewController
+  public let title: String
+  
+  init(viewController: UIViewController) {
+    self.viewController = viewController
+    self.title = viewController.title ?? ""
+  }
+}
+
+public func ==(lhs: ViewControllerItem, rhs: ViewControllerItem) -> Bool {
+  return lhs.viewController == rhs.viewController
+}


### PR DESCRIPTION
Add delegate that is called when transitioning to a ViewControllerItem
with its index in the menu items. Allows you to track which view
controller that is currently or about to be selected.