### PR TITLE
Fix bug where selecting items was not working

### DIFF
--- a/Parchment/Classes/PagingStateMachine.swift
+++ b/Parchment/Classes/PagingStateMachine.swift
@@ -32,6 +32,8 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
         animated: animated)
     case .finishScrolling:
       handleFinishScrollingEvent(event)
+    case .transitionSize:
+      handleTransitionSizeEvent(event)
     case .cancelScrolling:
       handleCancelScrollingEvent(event)
     }
@@ -105,6 +107,17 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
     switch state {
     case let .scrolling(currentPagingItem, upcomingPagingItem, _):
       state = .selected(pagingItem: upcomingPagingItem ?? currentPagingItem)
+      didChangeState?(oldState, state, event)
+    case .selected:
+      break
+    }
+  }
+  
+  fileprivate func handleTransitionSizeEvent(_ event: PagingEvent<T>) {
+    let oldState = state
+    switch state {
+    case let .scrolling(currentPagingItem, _, _):
+      state = .selected(pagingItem: currentPagingItem)
       didChangeState?(oldState, state, event)
     case .selected:
       break

--- a/Parchment/Enums/PagingEvent.swift
+++ b/Parchment/Enums/PagingEvent.swift
@@ -4,6 +4,7 @@ enum PagingEvent<T: PagingItem> where T: Equatable {
   case scroll(progress: CGFloat)
   case select(pagingItem: T, direction: PagingDirection, animated: Bool)
   case finishScrolling
+  case transitionSize
   case cancelScrolling
 }
 

--- a/ParchmentTests/PagingStateMachineSpec.swift
+++ b/ParchmentTests/PagingStateMachineSpec.swift
@@ -108,6 +108,35 @@ class PagingStateMachineSpec: QuickSpec {
         
       }
       
+      describe("transition size") {
+        
+        describe("is in the selected state") {
+          it("does not updated the state") {
+            stateMachine.fire(.transitionSize)
+            let expectedState: PagingState = .selected(pagingItem: Item(index: 0))
+            expect(stateMachine.state).to(equal(expectedState))
+          }
+        }
+        
+        describe("is in the scrolling state") {
+          
+          beforeEach {
+            let state: PagingState = .scrolling(
+              pagingItem: Item(index: 0),
+              upcomingPagingItem: Item(index: 1),
+              progress: 0.5)
+            stateMachine = PagingStateMachine(initialState: state)
+          }
+          
+          it("selects the current paging item") {
+            stateMachine.fire(.transitionSize)
+            expect(stateMachine.state).to(equal(PagingState.selected(pagingItem: Item(index: 0))))
+          }
+          
+        }
+        
+      }
+      
       describe("cancel scrolling") {
         
         describe("is in the selected state") {


### PR DESCRIPTION
Scrolling outside from either of the edges disabled interaction with
the menu items. This was caused by not resetting the state back to
.selected after the transition completed. Now we trigger a new event
when a transition has cancelled. We also rename the previous event
called cancelScrolling to transitionSize and use the cancelScrolling
event to reset the state back to selected.