### PR TITLE
Fix issues with FixedPagingViewControllerDelegate

### DIFF
--- a/Parchment/Classes/FixedPagingViewController.swift
+++ b/Parchment/Classes/FixedPagingViewController.swift
@@ -48,15 +48,17 @@ open class FixedPagingViewController: PagingViewController<ViewControllerItem> {
   open override func em_pageViewController(_ pageViewController: EMPageViewController, didFinishScrollingFrom startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {
     super.em_pageViewController(pageViewController, didFinishScrollingFrom: startingViewController, destinationViewController: destinationViewController, transitionSuccessful: transitionSuccessful)
     
-    if let index = items.index(where: { $0.viewController == destinationViewController }) {
-      itemDelegate?.fixedPagingViewController(
-        fixedPagingViewController: self,
-        didScrollToItem: items[index],
-        atIndex: index)
+    if transitionSuccessful {
+      if let index = items.index(where: { $0.viewController == destinationViewController }) {
+        itemDelegate?.fixedPagingViewController(
+          fixedPagingViewController: self,
+          didScrollToItem: items[index],
+          atIndex: index)
+      }
     }
   }
   
-  public func em_pageViewController(_ pageViewController: EMPageViewController, willStartScrollingFrom startingViewController: UIViewController, destinationViewController: UIViewController) {
+  open override func em_pageViewController(_ pageViewController: EMPageViewController, willStartScrollingFrom startingViewController: UIViewController, destinationViewController: UIViewController) {
     if let index = items.index(where: { $0.viewController == destinationViewController }) {
       itemDelegate?.fixedPagingViewController(
         fixedPagingViewController: self,

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -514,6 +514,10 @@ open class PagingViewController<T: PagingItem>:
     stateMachine?.fire(.scroll(progress: progress))
   }
   
+  public func em_pageViewController(_ pageViewController: EMPageViewController, willStartScrollingFrom startingViewController: UIViewController, destinationViewController: UIViewController) {
+    return
+  }
+  
   open func em_pageViewController(_ pageViewController: EMPageViewController, didFinishScrollingFrom startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {
     guard let state = stateMachine?.state else { return }
     


### PR DESCRIPTION
The didScrollToItem(:) delegate method gets called even if the
transition gets cancelled, which is fixed by checking for the
transitionSuccessful flag.

It also turn out the willScrollToItem(:) delegate is not called at all
because the PagingViewController does not implement this method.