### PR TITLE
Replace auto-layout with manual frames for menu cells

### DIFF
--- a/CalendarExample/CalendarPagingCell.swift
+++ b/CalendarExample/CalendarPagingCell.swift
@@ -27,55 +27,31 @@ class CalendarPagingCell: PagingCell {
     configure()
   }
   
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    let insets = UIEdgeInsets(top: 10, left: 0, bottom: 5, right: 0)
+    
+    dateLabel.frame = CGRect(
+      x: 0,
+      y: insets.top,
+      width: contentView.bounds.width,
+      height: contentView.bounds.midY - insets.top)
+    
+    weekdayLabel.frame = CGRect(
+      x: 0,
+      y: contentView.bounds.midY,
+      width: contentView.bounds.width,
+      height: contentView.bounds.midY - insets.bottom)
+  }
+  
   fileprivate func configure() {
-    addSubview(dateLabel)
+    weekdayLabel.backgroundColor = .white
+    weekdayLabel.textAlignment = .center
+    dateLabel.backgroundColor = .white
+    dateLabel.textAlignment = .center
+    
     addSubview(weekdayLabel)
-    
-    dateLabel.translatesAutoresizingMaskIntoConstraints = false
-    weekdayLabel.translatesAutoresizingMaskIntoConstraints = false
-    
-    let verticalDateLabelContraint = NSLayoutConstraint(
-      item: dateLabel,
-      attribute: .centerY,
-      relatedBy: .equal,
-      toItem: self,
-      attribute: .centerY,
-      multiplier: 1.0,
-      constant: -9)
-    
-    let horizontalDateLabelContraint = NSLayoutConstraint(
-      item: dateLabel,
-      attribute: .centerX,
-      relatedBy: .equal,
-      toItem: self,
-      attribute: .centerX,
-      multiplier: 1.0,
-      constant: 0)
-    
-    let verticalWeekdayLabelContraint = NSLayoutConstraint(
-      item: weekdayLabel,
-      attribute: .centerY,
-      relatedBy: .equal,
-      toItem: self,
-      attribute: .centerY,
-      multiplier: 1.0,
-      constant: 12)
-    
-    let horizontalWeekdayLabelContraint = NSLayoutConstraint(
-      item: weekdayLabel,
-      attribute: .centerX,
-      relatedBy: .equal,
-      toItem: self,
-      attribute: .centerX,
-      multiplier: 1.0,
-      constant: 0)
-    
-    addConstraints([
-      verticalDateLabelContraint,
-      horizontalDateLabelContraint,
-      verticalWeekdayLabelContraint,
-      horizontalWeekdayLabelContraint
-    ])
+    addSubview(dateLabel)
   }
   
   fileprivate func updateSelectedState(selected: Bool) {
@@ -91,8 +67,8 @@ class CalendarPagingCell: PagingCell {
   
   override func setPagingItem(_ pagingItem: PagingItem, selected: Bool, theme: PagingTheme) {
     let calendarItem = pagingItem as! CalendarItem
-    dateLabel.text = DateFormatters.dateFormatter.string(from: calendarItem.date)
-    weekdayLabel.text = DateFormatters.weekdayFormatter.string(from: calendarItem.date)
+    dateLabel.text = calendarItem.dateText
+    weekdayLabel.text = calendarItem.weekdayText
     
     self.theme = theme
     updateSelectedState(selected: selected)

--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -7,6 +7,14 @@ import Parchment
 // since that is required by PagingViewController
 struct CalendarItem: PagingItem, Equatable, Hashable, Comparable {
   let date: Date
+  let dateText: String
+  let weekdayText: String
+  
+  init(date: Date) {
+    self.date = date
+    self.dateText = DateFormatters.dateFormatter.string(from: date)
+    self.weekdayText = DateFormatters.weekdayFormatter.string(from: date)
+  }
   
   var hashValue: Int {
     return date.hashValue

--- a/Parchment/Classes/PagingCell.swift
+++ b/Parchment/Classes/PagingCell.swift
@@ -4,7 +4,11 @@ import UIKit
 /// items. When creating your own custom cells, you need to subclass
 /// this type instead of `UICollectionViewCell` directly.
 open class PagingCell: UICollectionViewCell {
-
+  
+  open override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+    return layoutAttributes
+  }
+  
   /// Called by the `PagingViewControllerDataSource` to customize the
   /// cell with an instance conforming to `PagingItem`. You have to
   /// override this method when creating your own subclass – the
@@ -19,4 +23,5 @@ open class PagingCell: UICollectionViewCell {
   open func setPagingItem(_ pagingItem: PagingItem, selected: Bool, theme: PagingTheme) {
     fatalError("setPagingItem: not implemented")
   }
+  
 }

--- a/Parchment/Classes/PagingTitleCell.swift
+++ b/Parchment/Classes/PagingTitleCell.swift
@@ -38,7 +38,11 @@ open class PagingTitleCell: PagingCell {
   
   open func configure() {
     contentView.addSubview(titleLabel)
-    contentView.constrainToEdges(titleLabel)
+  }
+  
+  open override func layoutSubviews() {
+    super.layoutSubviews()
+    titleLabel.frame = contentView.bounds
   }
   
   open func configureTitleLabel() {


### PR DESCRIPTION
Scroll performance in the menu items sometimes have a tiny glitch,
especially when it needs to re-calculate the menu items while
scrolling. Using manual frames instead of auto-layout improves the
performance and causes the glitch to disappear.