### PR TITLE
Allow setting different width for selected cell

### DIFF
--- a/DelegateExample/ViewController.swift
+++ b/DelegateExample/ViewController.swift
@@ -63,10 +63,10 @@ extension ViewController: PagingViewControllerDelegate {
   // can access the title string by casting the paging item to a
   // PagingTitleItem, which is the PagingItem type used by
   // FixedPagingViewController.
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, widthForPagingItem pagingItem: T) -> CGFloat {
+  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, widthForPagingItem pagingItem: T, isSelected: Bool) -> CGFloat {
     
-    guard let item = pagingItem as? PagingTitleItem else { return 0 }
-    
+    guard let item = pagingItem as? ViewControllerItem else { return 0 }
+
     let options = pagingViewController.options
     let insets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
     let size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: options.menuItemSize.height)
@@ -76,8 +76,14 @@ extension ViewController: PagingViewControllerDelegate {
       options: .usesLineFragmentOrigin,
       attributes: attributes,
       context: nil)
+
+    let width = ceil(rect.width) + insets.left + insets.right
     
-    return ceil(rect.width) + insets.left + insets.right
+    if isSelected {
+      return width * 1.5
+    } else {
+      return width
+    }
   }
   
 }

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -85,10 +85,11 @@
 		954842571F4243610072038C /* InvalidationSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842561F4243610072038C /* InvalidationSummary.swift */; };
 		954842591F42438E0072038C /* PagingInvalidationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842581F42438E0072038C /* PagingInvalidationContext.swift */; };
 		9548425D1F42486B0072038C /* PagingDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9548425C1F42486B0072038C /* PagingDiff.swift */; };
-		9548425F1F424F640072038C /* PagingCollectionViewLayoutDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9548425E1F424F640072038C /* PagingCollectionViewLayoutDelegate.swift */; };
 		954842611F4251F90072038C /* PagingViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842601F4251F90072038C /* PagingViewControllerSpec.swift */; };
 		954842631F4252070072038C /* PagingDiffSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842621F4252070072038C /* PagingDiffSpec.swift */; };
 		954E7DEE1F48AE6E00342ECF /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954E7DEB1F48AE1300342ECF /* Item.swift */; };
+		955444B11FC99E2C001EC26B /* PagingSizeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955444B01FC99E2C001EC26B /* PagingSizeCache.swift */; };
+		955444B41FC9A7C3001EC26B /* PagingSizeCacheDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955444B31FC9A7C3001EC26B /* PagingSizeCacheDelegate.swift */; };
 		955F23491EBA733B005F45E6 /* ViewControllerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955F23481EBA733B005F45E6 /* ViewControllerItem.swift */; };
 		957F14091E35583500E562F8 /* PagingCellLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */; };
 		9597F2951E3903F4003FD289 /* UIColor+interpolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9597F2941E3903F4003FD289 /* UIColor+interpolation.swift */; };
@@ -328,10 +329,11 @@
 		954842561F4243610072038C /* InvalidationSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvalidationSummary.swift; sourceTree = "<group>"; };
 		954842581F42438E0072038C /* PagingInvalidationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingInvalidationContext.swift; sourceTree = "<group>"; };
 		9548425C1F42486B0072038C /* PagingDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDiff.swift; sourceTree = "<group>"; };
-		9548425E1F424F640072038C /* PagingCollectionViewLayoutDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingCollectionViewLayoutDelegate.swift; sourceTree = "<group>"; };
 		954842601F4251F90072038C /* PagingViewControllerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingViewControllerSpec.swift; sourceTree = "<group>"; };
 		954842621F4252070072038C /* PagingDiffSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDiffSpec.swift; sourceTree = "<group>"; };
 		954E7DEB1F48AE1300342ECF /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		955444B01FC99E2C001EC26B /* PagingSizeCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingSizeCache.swift; sourceTree = "<group>"; };
+		955444B31FC9A7C3001EC26B /* PagingSizeCacheDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingSizeCacheDelegate.swift; sourceTree = "<group>"; };
 		955F23481EBA733B005F45E6 /* ViewControllerItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerItem.swift; sourceTree = "<group>"; };
 		957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingCellLayoutAttributes.swift; sourceTree = "<group>"; };
 		9597F2941E3903F4003FD289 /* UIColor+interpolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+interpolation.swift"; sourceTree = "<group>"; };
@@ -503,6 +505,7 @@
 				3E562ACD1CE7CD8C007623B3 /* PagingTitleCell.swift */,
 				3E49C7231C8F5C13006269DD /* PagingView.swift */,
 				3E49C7241C8F5C13006269DD /* PagingViewController.swift */,
+				955444B01FC99E2C001EC26B /* PagingSizeCache.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -615,11 +618,11 @@
 			isa = PBXGroup;
 			children = (
 				3E4090801C88BBCF00800E22 /* ArithmeticType.swift */,
-				9548425E1F424F640072038C /* PagingCollectionViewLayoutDelegate.swift */,
 				3E2AAD2B1CA869B50044AAA5 /* PagingItem.swift */,
 				3E4189201C9573FA001E0284 /* PagingViewControllerDataSource.swift */,
 				3E2AAD2D1CA86A320044AAA5 /* PagingViewControllerDelegate.swift */,
 				951B33721F7C410F007C4F26 /* FixedPagingViewControllerDelegate.swift */,
+				955444B31FC9A7C3001EC26B /* PagingSizeCacheDelegate.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1070,6 +1073,7 @@
 				3E40909B1C88BCC900800E22 /* PagingEvent.swift in Sources */,
 				9548425D1F42486B0072038C /* PagingDiff.swift in Sources */,
 				951B33731F7C410F007C4F26 /* FixedPagingViewControllerDelegate.swift in Sources */,
+				955444B41FC9A7C3001EC26B /* PagingSizeCacheDelegate.swift in Sources */,
 				3E40909D1C88BCC900800E22 /* PagingState.swift in Sources */,
 				954842591F42438E0072038C /* PagingInvalidationContext.swift in Sources */,
 				9597F2951E3903F4003FD289 /* UIColor+interpolation.swift in Sources */,
@@ -1086,11 +1090,11 @@
 				3E4189211C9573FA001E0284 /* PagingViewControllerDataSource.swift in Sources */,
 				3E2AAD2C1CA869B50044AAA5 /* PagingItem.swift in Sources */,
 				3E40909C1C88BCC900800E22 /* PagingOptions.swift in Sources */,
-				9548425F1F424F640072038C /* PagingCollectionViewLayoutDelegate.swift in Sources */,
 				3E4090B11C88BDD100800E22 /* PagingIndicatorLayoutAttributes.swift in Sources */,
 				952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */,
 				954842571F4243610072038C /* InvalidationSummary.swift in Sources */,
 				3E4090AE1C88BDD100800E22 /* PagingBorderLayoutAttributes.swift in Sources */,
+				955444B11FC99E2C001EC26B /* PagingSizeCache.swift in Sources */,
 				3E4283FC1C99CF9000032D95 /* PagingDataStructure.swift in Sources */,
 				3E49C7281C8F5C13006269DD /* PagingIndicatorView.swift in Sources */,
 				95B301171E59FCD500B95D02 /* UIEdgeInsets.swift in Sources */,

--- a/Parchment/Classes/PagingInvalidationContext.swift
+++ b/Parchment/Classes/PagingInvalidationContext.swift
@@ -3,5 +3,5 @@ import UIKit
 open class PagingInvalidationContext: UICollectionViewLayoutInvalidationContext {
   var invalidateContentOffset: Bool = false
   var invalidateTransition: Bool = false
+  var invalidateSizes: Bool = false
 }
-

--- a/Parchment/Classes/PagingSizeCache.swift
+++ b/Parchment/Classes/PagingSizeCache.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+class PagingSizeCache<T: PagingItem>  where T: Hashable, T: Comparable {
+  
+  var implementsWidthDelegate: Bool = false
+  weak var delegate: PagingSizeCacheDelegate?
+  
+  private let options: PagingOptions
+  private var widthCache: [T: CGFloat] = [:]
+  private var selectedWidthCache: [T: CGFloat] = [:]
+  
+  init(options: PagingOptions) {
+    self.options = options
+    
+    NotificationCenter.default.addObserver(self,
+      selector: #selector(applicationDidEnterBackground(notification:)),
+      name: NSNotification.Name.UIApplicationDidEnterBackground,
+      object: nil)
+    
+    NotificationCenter.default.addObserver(self,
+      selector: #selector(didReceiveMemoryWarning(notification:)),
+      name: NSNotification.Name.UIApplicationDidReceiveMemoryWarning,
+      object: nil)
+  }
+  
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+  }
+  
+  func clear() {
+    self.widthCache =  [:]
+    self.selectedWidthCache = [:]
+  }
+  
+  func itemWidth(for pagingItem: T) -> CGFloat {
+    if let width = widthCache[pagingItem] {
+      return width
+    } else {
+      let width = delegate?.pagingSizeCache(self, widthForPagingItem: pagingItem, isSelected: false)
+      widthCache[pagingItem] = width
+      return width ?? options.estimatedItemWidth
+    }
+  }
+  
+  func itemWidthSelected(for pagingItem: T) -> CGFloat {
+    if let width = selectedWidthCache[pagingItem] {
+      return width
+    } else {
+      let width = delegate?.pagingSizeCache(self, widthForPagingItem: pagingItem, isSelected: true)
+      selectedWidthCache[pagingItem] = width
+      return width ?? options.estimatedItemWidth
+    }
+  }
+  
+  @objc private func didReceiveMemoryWarning(notification: NSNotification) {
+    self.clear()
+  }
+  
+  @objc private func applicationDidEnterBackground(notification: NSNotification) {
+    self.clear()
+  }
+  
+}

--- a/Parchment/Enums/InvalidationSummary.swift
+++ b/Parchment/Enums/InvalidationSummary.swift
@@ -12,6 +12,7 @@ enum InvalidationSummary {
   case dataSourceCounts
   case contentOffset
   case transition
+  case sizes
   
   init(_ invalidationContext: UICollectionViewLayoutInvalidationContext) {
     if invalidationContext.invalidateEverything {
@@ -21,6 +22,8 @@ enum InvalidationSummary {
     } else if let context = invalidationContext as? PagingInvalidationContext {
       if context.invalidateTransition {
         self = .transition
+      } else if context.invalidateSizes {
+        self = .sizes
       } else if context.invalidateContentOffset {
         self = .contentOffset
       } else {
@@ -39,6 +42,8 @@ enum InvalidationSummary {
       return .everything
     case (.dataSourceCounts, _), (_, .dataSourceCounts):
       return .dataSourceCounts
+    case (.sizes, _), (_, .sizes):
+      return .sizes
     case (.transition, _), (_, .transition):
       return .transition
     case (.contentOffset, _), (_, .contentOffset):

--- a/Parchment/Protocols/PagingCollectionViewLayoutDelegate.swift
+++ b/Parchment/Protocols/PagingCollectionViewLayoutDelegate.swift
@@ -1,6 +1,0 @@
-import Foundation
-
-protocol PagingCollectionViewLayoutDelegate: class {
-  func pagingCollectionViewLayout<T>(_ pagingCollectionViewLayout: PagingCollectionViewLayout<T>, widthForIndexPath indexPath: IndexPath) -> CGFloat
-}
-

--- a/Parchment/Protocols/PagingSizeCacheDelegate.swift
+++ b/Parchment/Protocols/PagingSizeCacheDelegate.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol PagingSizeCacheDelegate: class {
+  func pagingSizeCache<T>(
+    _ pagingSizeCache: PagingSizeCache<T>,
+    widthForPagingItem pagingItem: T,
+    isSelected: Bool) -> CGFloat?
+}

--- a/Parchment/Protocols/PagingViewControllerDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerDelegate.swift
@@ -11,8 +11,11 @@ public protocol PagingViewControllerDelegate: class {
   /// - Parameter pagingViewController: The `PagingViewController`
   /// instance
   /// - Parameter pagingItem: The `PagingItem` instance
+  /// - Parameter isSelected: A boolean that indicates whether the
+  /// given `PagingItem` is selected
   /// - Returns: The width for the `PagingItem`
   func pagingViewController<T>(
     _ pagingViewController: PagingViewController<T>,
-    widthForPagingItem pagingItem: T) -> CGFloat
+    widthForPagingItem pagingItem: T,
+    isSelected: Bool) -> CGFloat
 }


### PR DESCRIPTION
The widthForPagingItem delegate now has a new argument called
isSelected which can be used to return a different width for the
currently selected cell. Parchment will then tween between the selected
width and the default width when swiping between items.

If you implement the width delegate, the collection view layout will
invalidate all the layout attributes as you are scrolling. The menu
item sizes are cached so they are not re-calculated all the time.