### PR TITLE
Fix issue with wrong distance calculation causing flicker

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -272,7 +272,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
           let center = view.bounds.midX
           let centerAfterTransition = to.frame.midX - distance
           if centerAfterTransition < center {
-            distance = originalDistance
+            distance = view.contentSize.width - (view.contentOffset.x + view.bounds.width)
           }
         }
       }


### PR DESCRIPTION
When moving from the last item to the item in center, the calculated
distance was wrong if the item was not exactly centered. This caused
the menu items to flicker when scrolling to that item.