### PR TITLE
Add option to always center selected menu item

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -21,6 +21,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   var state: PagingState<T>?
   var dataStructure: PagingDataStructure<T>
   var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] = [:]
+  var contentInsets: UIEdgeInsets = .zero
   
   open override var collectionViewContentSize: CGSize {
     return contentSize
@@ -232,7 +233,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
       distance = distanceToLeftAlignedItem()
     case .right:
       distance = distanceToRightAlignedItem()
-    case .preferCentered:
+    case .preferCentered, .center:
       distance = distanceToCenteredItem()
     }
     
@@ -438,9 +439,35 @@ open class PagingCollectionViewLayout<T: PagingItem>:
       }
     }
     
-    contentSize = CGSize(
-      width: previousFrame.maxX + adjustedMenuInsets.right,
-      height: view.bounds.height)
+    if case .center = options.selectedScrollPosition {
+      let attributes = layoutAttributes.values.sorted(by: { $0.indexPath < $1.indexPath })
+      
+      if let first = attributes.first, let last = attributes.last {
+        let insetLeft = (view.bounds.width / 2) - (first.bounds.width / 2)
+        let insetRight = (view.bounds.width / 2) - (last.bounds.width / 2)
+        
+        for attributes in layoutAttributes.values {
+          attributes.frame = attributes.frame.offsetBy(dx: insetLeft, dy: 0)
+        }
+        
+        contentInsets = UIEdgeInsets(
+          top: 0,
+          left: insetLeft + adjustedMenuInsets.left,
+          bottom: 0,
+          right: insetRight + adjustedMenuInsets.right)
+        
+        contentSize = CGSize(
+          width: previousFrame.maxX + insetLeft + insetRight + adjustedMenuInsets.right,
+          height: view.bounds.height)
+      }
+      
+    } else {
+      contentInsets = adjustedMenuInsets
+      contentSize = CGSize(
+        width: previousFrame.maxX + adjustedMenuInsets.right,
+        height: view.bounds.height)
+    }
+    
     
     self.layoutAttributes = layoutAttributes
   }

--- a/Parchment/Classes/PagingOptions.swift
+++ b/Parchment/Classes/PagingOptions.swift
@@ -22,7 +22,7 @@ open class PagingOptions {
       return .left
     case .right:
       return .right
-    case .preferCentered:
+    case .preferCentered, .center:
       return .centeredHorizontally
     }
   }

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -688,13 +688,13 @@ open class PagingViewController<T: PagingItem>:
       return
     }
     
-    if scrollView.near(edge: .left) {
+    if scrollView.near(edge: .left, clearance: collectionViewLayout.contentInsets.left) {
       if let firstPagingItem = dataStructure.sortedItems.first {
         if dataStructure.hasItemsBefore {
           reloadItems(around: firstPagingItem)
         }
       }
-    } else if scrollView.near(edge: .right) {
+    } else if scrollView.near(edge: .right, clearance: collectionViewLayout.contentInsets.right) {
       if let lastPagingItem = dataStructure.sortedItems.last {
         if dataStructure.hasItemsAfter {
           reloadItems(around: lastPagingItem)

--- a/Parchment/Enums/PagingSelectedScrollPosition.swift
+++ b/Parchment/Enums/PagingSelectedScrollPosition.swift
@@ -3,6 +3,7 @@ import Foundation
 public enum PagingSelectedScrollPosition {
   case left
   case right
+  case center
   
   /// Centers the selected menu item where possible. If the item is
   /// to the far left or right, it will not update the scroll


### PR DESCRIPTION
The preferCentered option on the selectedScrollPosition property will
only center the selected menu item if it’s not too close to the edges.
With the new center option it will make sure the selected menu item is
always centered.