### PR TITLE
Fix layout calculation when using transforms

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -622,12 +622,12 @@ open class PagingViewController<T: PagingItem>:
     let diff = PagingDiff(from: oldDataStructure, to: dataStructure)
     
     for indexPath in diff.removed() {
-      offset += oldLayoutAttributes[indexPath]?.frame.width ?? 0
+      offset += oldLayoutAttributes[indexPath]?.bounds.width ?? 0
       offset += options.menuItemSpacing
     }
     
     for indexPath in diff.added() {
-      offset -= collectionViewLayout.layoutAttributes[indexPath]?.frame.width ?? 0
+      offset -= collectionViewLayout.layoutAttributes[indexPath]?.bounds.width ?? 0
       offset -= options.menuItemSpacing
     }
     


### PR DESCRIPTION
When applying transforms to the menu cells the layout calculations
would give the wrong result. This happens because the frame property is
just a computed value that’s based on the center, bounds and transform
properties. We therefore need to read from bounds and center properties
directly to prevent the layout calculation to be affected by any
transforms.