### PR TITLE
 Allow subclassing the collection view layout

### DIFF
--- a/NavigationBarExample/ViewController.swift
+++ b/NavigationBarExample/ViewController.swift
@@ -9,6 +9,7 @@ import Parchment
 class CustomPagingView: PagingView {
   
   override func setupConstraints() {
+    guard let pageView = pageView else { return }
     // Use our convenience extension to constrain the page view to all
     // of the edges of the super view.
     constrainToEdges(pageView)
@@ -19,10 +20,7 @@ class CustomPagingView: PagingView {
 // our own custom subclass.
 class CustomPagingViewController: FixedPagingViewController {
   override func loadView() {
-    view = CustomPagingView(
-      pageView: pageViewController.view,
-      collectionView: collectionView,
-      options: options)
+    view = CustomPagingView(options: options)
   }
 }
 

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		959C9F551FF14AF6005F0ED2 /* Parchment.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		959C9F5A1FF14B4F005F0ED2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 959C9F591FF14B4F005F0ED2 /* Main.storyboard */; };
 		95A0AF001FF707910043B90A /* IndexedPagingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A0AEFF1FF707910043B90A /* IndexedPagingItem.swift */; };
+		95A52A151FF81F70002A2ED4 /* PagingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A52A141FF81F70002A2ED4 /* PagingLayout.swift */; };
 		95B301001E59E43800B95D02 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B300FF1E59E43800B95D02 /* AppDelegate.swift */; };
 		95B301021E59E43800B95D02 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B301011E59E43800B95D02 /* ViewController.swift */; };
 		95B301051E59E43800B95D02 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95B301031E59E43800B95D02 /* Main.storyboard */; };
@@ -398,6 +399,7 @@
 		959C9F591FF14B4F005F0ED2 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		959C9F5B1FF14BB8005F0ED2 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		95A0AEFF1FF707910043B90A /* IndexedPagingItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexedPagingItem.swift; sourceTree = "<group>"; };
+		95A52A141FF81F70002A2ED4 /* PagingLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingLayout.swift; sourceTree = "<group>"; };
 		95B300FD1E59E43800B95D02 /* StoryboardExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StoryboardExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95B300FF1E59E43800B95D02 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95B301011E59E43800B95D02 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -692,6 +694,7 @@
 				3E2AAD2D1CA86A320044AAA5 /* PagingViewControllerDelegate.swift */,
 				955444B31FC9A7C3001EC26B /* PagingSizeCacheDelegate.swift */,
 				955444B51FC9CC69001EC26B /* PagingTheme.swift */,
+				95A52A141FF81F70002A2ED4 /* PagingLayout.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -1183,6 +1186,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3EF3C1E31CA0870E00CDFE26 /* FixedPagingViewController.swift in Sources */,
+				95A52A151FF81F70002A2ED4 /* PagingLayout.swift in Sources */,
 				955444C21FC9CD19001EC26B /* PagingMenuTransition.swift in Sources */,
 				3E2AAD2E1CA86A320044AAA5 /* PagingViewControllerDelegate.swift in Sources */,
 				3E4090821C88BBCF00800E22 /* ArithmeticType.swift in Sources */,

--- a/Parchment/Classes/PagingBorderLayoutAttributes.swift
+++ b/Parchment/Classes/PagingBorderLayoutAttributes.swift
@@ -1,9 +1,9 @@
 import UIKit
 
-class PagingBorderLayoutAttributes: UICollectionViewLayoutAttributes {
+public class PagingBorderLayoutAttributes: UICollectionViewLayoutAttributes {
   
-  var backgroundColor: UIColor?
-  var insets: UIEdgeInsets = UIEdgeInsets()
+  public var backgroundColor: UIColor?
+  public var insets: UIEdgeInsets = UIEdgeInsets()
   
   func configure(_ options: PagingOptions, safeAreaInsets: UIEdgeInsets = .zero) {
     if case let .visible(height, index, borderInsets) = options.borderOptions {

--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -22,7 +22,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   public var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] = [:]
   public var indicatorLayoutAttributes: PagingIndicatorLayoutAttributes?
   public var borderLayoutAttributes: PagingBorderLayoutAttributes?
-  public var invalidationSummary: InvalidationSummary = .everything
+  public var invalidationState: InvalidationState = .everything
   
   open override var collectionViewContentSize: CGSize {
     return contentSize
@@ -78,8 +78,8 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   open override func prepare() {
     super.prepare()
     
-    switch invalidationSummary {
-    case .everything, .dataSourceCounts:
+    switch invalidationState {
+    case .everything:
       layoutAttributes = [:]
       borderLayoutAttributes = nil
       indicatorLayoutAttributes = nil
@@ -94,19 +94,19 @@ open class PagingCollectionViewLayout<T: PagingItem>:
       layoutAttributes = [:]
       createLayoutAttributes()
       invalidateContentOffset()
-    case .partial:
+    case .nothing:
       break
     }
     
     updateBorderLayoutAttributes()
     updateIndicatorLayoutAttributes()
     
-    invalidationSummary = .partial
+    invalidationState = .nothing
   }
   
   override open func invalidateLayout(with context: UICollectionViewLayoutInvalidationContext) {
     super.invalidateLayout(with: context)
-    invalidationSummary = invalidationSummary + InvalidationSummary(context)
+    invalidationState = invalidationState + InvalidationState(context)
   }
   
   override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {

--- a/Parchment/Classes/PagingIndicatorLayoutAttributes.swift
+++ b/Parchment/Classes/PagingIndicatorLayoutAttributes.swift
@@ -1,8 +1,8 @@
 import UIKit
 
-class PagingIndicatorLayoutAttributes: UICollectionViewLayoutAttributes {
+public class PagingIndicatorLayoutAttributes: UICollectionViewLayoutAttributes {
 
-  var backgroundColor: UIColor?
+  public var backgroundColor: UIColor?
   
   func configure(_ options: PagingOptions) {
     if case let .visible(height, index, _, _) = options.indicatorOptions {

--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -9,24 +9,17 @@ import UIKit
 /// `loadView:` in `PagingViewController` to use your subclass.
 open class PagingView: UIView {
   
-  open let pageView: UIView
-  open let collectionView: UICollectionView
   open let options: PagingOptions
+  open var collectionView: UICollectionView?
+  open var pageView: UIView?
   
   /// Creates an instance of `PagingView`.
   ///
-  /// - Parameter pageView: The view assosicated with the
-  /// `EMPageViewController`.
-  /// - Parameter collectionView: The collection view used to display
-  /// the menu items.
   /// - Parameter options: The `PagingOptions` passed into the
   /// `PagingViewController`.
-  public init(pageView: UIView, collectionView: UICollectionView, options: PagingOptions) {
-    self.pageView = pageView
-    self.collectionView = collectionView
+  public init(options: PagingOptions) {
     self.options = options
     super.init(frame: .zero)
-    configure()
   }
   
   required public init?(coder: NSCoder) {
@@ -36,7 +29,10 @@ open class PagingView: UIView {
   /// Configures the view hierarchy, sets up the layout constraints
   /// and does any other customization based on the `PagingOptions`.
   /// Override this if you need any custom behavior.
-  open func configure() {
+  open func configure(collectionView: UICollectionView, pageView: UIView) {
+    self.collectionView = collectionView
+    self.pageView = pageView
+    
     collectionView.backgroundColor = options.theme.headerBackgroundColor
     addSubview(pageView)
     addSubview(collectionView)
@@ -46,6 +42,8 @@ open class PagingView: UIView {
   /// Sets up all the layout constraints. Override this if you need to
   /// make changes to how the views are layed out.
   open func setupConstraints() {
+    guard let pageView = pageView, let collectionView = collectionView else { return }
+    
     collectionView.translatesAutoresizingMaskIntoConstraints = false
     pageView.translatesAutoresizingMaskIntoConstraints = false
     

--- a/Parchment/Enums/InvalidationSummary.swift
+++ b/Parchment/Enums/InvalidationSummary.swift
@@ -4,12 +4,11 @@ import UIKit
 /// layout. We need to be able to invalidate the layout multiple times
 /// with different invalidation contexts before `invalidateLayout` is
 /// called and we can use we can use this to determine exactly how
-/// much we need to invalidate by adding together the summaries each
+/// much we need to invalidate by adding together the states each
 /// time a new context is invalidated.
-public enum InvalidationSummary {
-  case partial
+public enum InvalidationState {
+  case nothing
   case everything
-  case dataSourceCounts
   case contentOffset
   case transition
   case sizes
@@ -18,7 +17,7 @@ public enum InvalidationSummary {
     if invalidationContext.invalidateEverything {
       self = .everything
     } else if invalidationContext.invalidateDataSourceCounts {
-      self = .dataSourceCounts
+      self = .everything
     } else if let context = invalidationContext as? PagingInvalidationContext {
       if context.invalidateTransition {
         self = .transition
@@ -27,29 +26,25 @@ public enum InvalidationSummary {
       } else if context.invalidateContentOffset {
         self = .contentOffset
       } else {
-        self = .partial
+        self = .nothing
       }
     } else {
-      self = .partial
+      self = .nothing
     }
   }
   
-  static func +(lhs: InvalidationSummary, rhs: InvalidationSummary) -> InvalidationSummary {
+  static func +(lhs: InvalidationState, rhs: InvalidationState) -> InvalidationState {
     switch (lhs, rhs) {
     case (.everything, _), (_, .everything):
       return .everything
-    case (.dataSourceCounts, .dataSourceCounts):
-      return .everything
-    case (.dataSourceCounts, _), (_, .dataSourceCounts):
-      return .dataSourceCounts
     case (.sizes, _), (_, .sizes):
       return .sizes
     case (.transition, _), (_, .transition):
       return .transition
     case (.contentOffset, _), (_, .contentOffset):
       return .contentOffset
-    case (.partial, _), (_, .partial):
-      return .partial
+    case (.nothing, _), (_, .nothing):
+      return .nothing
     default:
       return .everything
     }

--- a/Parchment/Enums/InvalidationSummary.swift
+++ b/Parchment/Enums/InvalidationSummary.swift
@@ -6,7 +6,7 @@ import UIKit
 /// called and we can use we can use this to determine exactly how
 /// much we need to invalidate by adding together the summaries each
 /// time a new context is invalidated.
-enum InvalidationSummary {
+public enum InvalidationSummary {
   case partial
   case everything
   case dataSourceCounts

--- a/Parchment/Protocols/PagingLayout.swift
+++ b/Parchment/Protocols/PagingLayout.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Used to be able to initialize a layout based on the type defined
+/// in the menuLayoutClass property.
+protocol PagingLayout {
+  init(options: PagingOptions)
+}
+
+func createLayout<T>(layout: T.Type, options: PagingOptions) -> T where T: PagingLayout {
+  return layout.init(options: options)
+}

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -45,26 +45,26 @@ class PagingViewControllerSpec: QuickSpec {
       UIApplication.shared.keyWindow!.rootViewController = viewController
       let _ = viewController.view
       
-      viewController.collectionView.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
+      viewController.collectionView!.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
     }
     
     describe("PagingViewController") {
       
       it("reloadItems: at begining") {
         viewController.selectPagingItem(Item(index: 0))
-        let items = viewController.collectionView.numberOfItems(inSection: 0)
+        let items = viewController.collectionView!.numberOfItems(inSection: 0)
         expect(items).to(equal(21))
       }
       
       it("reloadItems: at center") {
         viewController.selectPagingItem(Item(index: 20))
-        let items = viewController.collectionView.numberOfItems(inSection: 0)
+        let items = viewController.collectionView!.numberOfItems(inSection: 0)
         expect(items).to(equal(21))
       }
       
       it("reloadItems: at end") {
         viewController.selectPagingItem(Item(index: 50))
-        let items = viewController.collectionView.numberOfItems(inSection: 0)
+        let items = viewController.collectionView!.numberOfItems(inSection: 0)
         expect(items).to(equal(21))
       }
       


### PR DESCRIPTION
Adds a property called menuLayoutClass that allows you to override the
PagingCollectionViewLayout class type. This means you can provide your
own subclass of the layout.

Since the collection view layout type will be set after the
PagingViewController has been initialized we need to wait to initialize
the collection view layout until the view has loaded. This means both
the collectionViewLayout and the collectionView are now optional. This
also means we need to update the initializer for the PagingView. It now
takes the collectionView and the pageView as arguments in the configure
function, which is called after the view has loaded.