### PR TITLE
Rename selectPagingItem to select(pagingItem:)

### DIFF
--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -55,7 +55,7 @@ class ViewController: UIViewController {
     pagingViewController.infiniteDataSource = self
     
     // Set the current date as the selected paging item
-    pagingViewController.selectPagingItem(CalendarItem(date: Date()))
+    pagingViewController.select(pagingItem: CalendarItem(date: Date()))
   }
   
 }

--- a/IconsExample/ViewController.swift
+++ b/IconsExample/ViewController.swift
@@ -67,7 +67,7 @@ class ViewController: UIViewController {
     pagingViewController.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
     pagingViewController.indicatorColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
     pagingViewController.dataSource = self
-    pagingViewController.selectPagingItem(IconItem(icon: icons[0], index: 0))
+    pagingViewController.select(pagingItem: IconItem(icon: icons[0], index: 0))
     
     // Add the paging view controller as a child view controller
     // and contrain it to all edges.

--- a/Parchment/Classes/FixedPagingViewController.swift
+++ b/Parchment/Classes/FixedPagingViewController.swift
@@ -11,22 +11,20 @@ import UIKit
 /// your own implementation that matches your needs.
 open class FixedPagingViewController: PagingViewController<PagingIndexItem> {
   
-  /// An array of `PagingItem`s that contains a reference to the view
-  /// controller and title for that item. If you need to call
-  /// `selectPagingItem:` you can read from this to get the item you
-  /// want to select.
+  /// An array of the content view controllers. If you need to call
+  /// `select(pagingItem:)` you can use the index of these view
+  /// controller to select the item you want.
   open let viewControllers: [UIViewController]
   
   /// Creates an instance of `FixedPagingViewController`. By default,
   /// it will select the first view controller in the array. You can
-  /// also call `selectPagingItem:` if you need select something else.
+  /// call `select(pagingItem:)` if you need select something else.
   ///
   /// - Parameter viewControllers: An array of view controllers
   public init(viewControllers: [UIViewController]) {
     self.viewControllers = viewControllers
     super.init()
     dataSource = self
-    selectPagingItem(PagingIndexItem(index: 0, title: viewControllers[0].title ?? ""))
   }
 
   required public init?(coder: NSCoder) {

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -10,9 +10,9 @@ import UIKit
 /// corresponds to each item. See `PagingViewControllerDataSource`.
 ///
 /// After providing a data source you need to call
-/// `selectPagingItem(pagingItem:animated:)` to set the initial view
-/// controller. You can also use the same method to programmatically
-/// navigate to other view controllers.
+/// `select(pagingItem:animated:)` to set the initial view controller.
+/// You can also use the same method to programmatically navigate to
+/// other view controllers.
 open class PagingViewController<T: PagingItem>:
   UIViewController,
   UICollectionViewDataSource,
@@ -243,8 +243,8 @@ open class PagingViewController<T: PagingItem>:
   fileprivate let PagingCellReuseIdentifier = "PagingCellReuseIdentifier"
 
   /// Creates an instance of `PagingViewController`. You need to call
-  /// `selectPagingItem(pagingItem:animated:)` in order to set the
-  /// initial view controller before any items become visible.
+  /// `select(pagingItem:animated:)` in order to set the initial view
+  /// controller before any items become visible.
   public init() {
     self.options = PagingOptions()
     self.dataStructure = PagingDataStructure(visibleItems: [])
@@ -287,7 +287,7 @@ open class PagingViewController<T: PagingItem>:
   /// - Parameter pagingItem: The `PagingItem` to be displayed.
   /// - Parameter animated: A boolean value that indicates whether
   /// the transtion should be animated. Default is false.
-  open func selectPagingItem(_ pagingItem: T, animated: Bool = false) {
+  open func select(pagingItem: T, animated: Bool = false) {
 
     if let stateMachine = stateMachine,
       let indexPath = dataStructure.indexPathForPagingItem(pagingItem) {
@@ -410,7 +410,7 @@ open class PagingViewController<T: PagingItem>:
     infiniteDataSource = indexedDataSource
 
     if let firstItem = items.first {
-      selectPagingItem(firstItem)
+      select(pagingItem: firstItem)
     }
   }
   
@@ -464,7 +464,7 @@ open class PagingViewController<T: PagingItem>:
     }
     
     if let item = upcomingPagingItem {
-      selectPagingItem(item, animated: true)
+      select(pagingItem: item, animated: true)
     }
   }
   

--- a/Parchment/Protocols/PagingViewControllerDataSource.swift
+++ b/Parchment/Protocols/PagingViewControllerDataSource.swift
@@ -6,7 +6,7 @@ import UIKit
 /// fixed number of view controllers.
 ///
 /// In order for these methods to be called, you first need to set the
-/// initial `PagingItem` by calling `selectPagingItem:` on
+/// initial `PagingItem` by calling `select(pagingItem:)` on
 /// `PagingViewController`.
 public protocol PagingViewControllerDataSource: class {
   

--- a/Parchment/Protocols/PagingViewControllerInfiniteDataSource.swift
+++ b/Parchment/Protocols/PagingViewControllerInfiniteDataSource.swift
@@ -5,7 +5,7 @@ import UIKit
 /// controller it is associated with.
 ///
 /// In order for these methods to be called, you first need to set
-/// the initial `PagingItem` by calling `selectPagingItem:` on
+/// the initial `PagingItem` by calling `select(pagingItem:)` on
 /// `PagingViewController`.
 public protocol PagingViewControllerInfiniteDataSource: class {
                                                     

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -51,19 +51,19 @@ class PagingViewControllerSpec: QuickSpec {
     describe("PagingViewController") {
       
       it("reloadItems: at begining") {
-        viewController.selectPagingItem(Item(index: 0))
+        viewController.select(pagingItem: Item(index: 0))
         let items = viewController.collectionView!.numberOfItems(inSection: 0)
         expect(items).to(equal(21))
       }
       
       it("reloadItems: at center") {
-        viewController.selectPagingItem(Item(index: 20))
+        viewController.select(pagingItem: Item(index: 20))
         let items = viewController.collectionView!.numberOfItems(inSection: 0)
         expect(items).to(equal(21))
       }
       
       it("reloadItems: at end") {
-        viewController.selectPagingItem(Item(index: 50))
+        viewController.select(pagingItem: Item(index: 50))
         let items = viewController.collectionView!.numberOfItems(inSection: 0)
         expect(items).to(equal(21))
       }

--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -126,7 +126,7 @@ class ViewController: UIViewController {
     pagingViewController.dataSource = self
     
     // Set the first item as the selected paging item.
-    pagingViewController.selectPagingItem(items[0])
+    pagingViewController.select(pagingItem: items[0])
   }
 
 }


### PR DESCRIPTION
More in line with the latest recommend Swift syntax.