### PR TITLE
Fix performance issue with updating content offset

### DIFF
--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		95B301191E59FD1600B95D02 /* UIScrollView+near.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B301181E59FD1600B95D02 /* UIScrollView+near.swift */; };
 		95F2CCA61E395762003C973E /* Parchment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; };
 		95F2CCA71E395762003C973E /* Parchment.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		95FE3AF91FFEDBCE00E6F2AD /* PagingDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95FE3AF81FFEDBCE00E6F2AD /* PagingDistance.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -394,6 +395,7 @@
 		95B301141E59E9BB00B95D02 /* UIView+constraints.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+constraints.swift"; sourceTree = "<group>"; };
 		95B301161E59FCD500B95D02 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		95B301181E59FD1600B95D02 /* UIScrollView+near.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIScrollView+near.swift"; sourceTree = "<group>"; };
+		95FE3AF81FFEDBCE00E6F2AD /* PagingDistance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDistance.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -524,6 +526,7 @@
 				3E49C72D1C8F5CCE006269DD /* PagingCellViewModel.swift */,
 				3E4283FB1C99CF9000032D95 /* PagingDataStructure.swift */,
 				9548425C1F42486B0072038C /* PagingDiff.swift */,
+				95FE3AF81FFEDBCE00E6F2AD /* PagingDistance.swift */,
 				3E4090A11C88BD0A00800E22 /* PagingIndicatorMetric.swift */,
 				952D802E1E37CC09003DCB18 /* PagingTransition.swift */,
 				955F23481EBA733B005F45E6 /* ViewControllerItem.swift */,
@@ -1195,6 +1198,7 @@
 				3E49C7261C8F5C13006269DD /* PagingCell.swift in Sources */,
 				3E49C72E1C8F5CCE006269DD /* PagingCellViewModel.swift in Sources */,
 				3E562ACE1CE7CD8C007623B3 /* PagingTitleCell.swift in Sources */,
+				95FE3AF91FFEDBCE00E6F2AD /* PagingDistance.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -21,6 +21,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   var state: PagingState<T>?
   var dataStructure: PagingDataStructure<T>
   var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] = [:]
+  var currentTransition: PagingTransition? = nil
   
   open override var collectionViewContentSize: CGSize {
     return contentSize
@@ -60,7 +61,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   private let borderLayoutAttributes: PagingBorderLayoutAttributes
   private var contentSize: CGSize = .zero
   private var invalidationSummary: InvalidationSummary = .everything
-  private var currentTransition: PagingTransition? = nil
+  
   private let PagingIndicatorKind = "PagingIndicatorKind"
   private let PagingBorderKind = "PagingBorderKind"
 
@@ -98,18 +99,9 @@ open class PagingCollectionViewLayout<T: PagingItem>:
     super.prepare()
     
     switch invalidationSummary {
-    case .everything, .dataSourceCounts:
+    case .everything, .dataSourceCounts, .sizes:
       layoutAttributes = [:]
       createLayoutAttributes()
-    case .contentOffset:
-      invalidateContentOffset()
-    case .transition:
-      invalidateTransition()
-      invalidateContentOffset()
-    case .sizes:
-      layoutAttributes = [:]
-      createLayoutAttributes()
-      invalidateContentOffset()
     case .partial:
       break
     }
@@ -169,208 +161,8 @@ open class PagingCollectionViewLayout<T: PagingItem>:
     
     return layoutAttributes
   }
-  
-  // The content offset and distance between items can change while a
-  // transition is in progress meaning the current transition will be
-  // wrong. For instance, when hitting the edge of the collection view
-  // while transitioning we need to reload all the paging items and
-  // update the transition data.
-  func updateCurrentTransition() {
-    let oldTransition = currentTransition
-    invalidateTransition()
-    
-    if let oldTransition = oldTransition,
-      let newTransition = currentTransition {
-      
-      let contentOffset = CGPoint(
-        x: view.contentOffset.x - (oldTransition.distance - newTransition.distance),
-        y: view.contentOffset.y)
-      
-      currentTransition = PagingTransition(
-        contentOffset: contentOffset,
-        distance: oldTransition.distance)
-    }
-  }
 
   // MARK: Private
-  
-  private func invalidateContentOffset() {
-    guard let state = state else { return }
-    
-    if options.menuTransition == .scrollAlongside {
-      if let transition = currentTransition {
-        
-        // FIXME: Remove the progress check and move state into
-        // invalidation context.
-        if contentSize.width >= view.bounds.width && state.progress != 0 {
-          let contentOffset = CGPoint(
-            x: transition.contentOffset.x + (transition.distance * fabs(state.progress)),
-            y: transition.contentOffset.y)
-          
-          // We need to use setContentOffset with no animation in
-          // order to stop any ongoing scroll.
-          view.setContentOffset(contentOffset, animated: false)
-        }
-      }
-    }
-  }
-  
-  /// In order to get the menu items to scroll alongside the content
-  /// we create a transition struct to keep track of the initial
-  /// content offset and the distance to the upcoming item so that we
-  /// can update the content offset as the user is swiping.
-  private func invalidateTransition() {
-    guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
-      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else {
-        
-        // When there is no upcomingIndexPath or any layout attributes
-        // for that item we have no way to determine the distance.
-        currentTransition = PagingTransition(
-          contentOffset: view.contentOffset,
-          distance: 0)
-        return
-    }
-    
-    var distance: CGFloat = 0
-    
-    switch (options.selectedScrollPosition) {
-    case .left:
-      distance = distanceToLeftAlignedItem()
-    case .right:
-      distance = distanceToRightAlignedItem()
-    case .preferCentered:
-      distance = distanceToCenteredItem()
-    }
-    
-    // Update the distance to account for cases where the user has
-    // scrolled all the way over to the other edge.
-    if view.near(edge: .left, clearance: -distance) && distance < 0 && dataStructure.hasItemsBefore == false {
-      distance = -(view.contentOffset.x + view.contentInset.left)
-    } else if view.near(edge: .right, clearance: distance) && distance > 0 &&
-      dataStructure.hasItemsAfter == false {
-      
-      distance = view.contentSize.width - (view.contentOffset.x + view.bounds.width)
-      
-      if sizeCache.implementsWidthDelegate {
-        let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
-        distance += toWidth - to.frame.width
-        
-        if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
-          let from = layoutAttributes[currentIndexPath] {
-          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
-          distance -= from.frame.width - fromWidth
-        }
-        
-        // If the selected cells grows so much that it will move
-        // beyond the center of the view, we want to update the
-        // distance after all.
-        if options.selectedScrollPosition == .preferCentered {
-          let center = view.bounds.midX
-          let centerAfterTransition = to.frame.midX - distance
-          if centerAfterTransition < center {
-            distance = view.contentSize.width - (view.contentOffset.x + view.bounds.width)
-          }
-        }
-      }
-    }
-    
-    currentTransition = PagingTransition(
-      contentOffset: view.contentOffset,
-      distance: distance)
-  }
-  
-  private func distanceToLeftAlignedItem() -> CGFloat {
-    guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
-      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
-    
-    var distance = to.frame.origin.x - view.contentOffset.x
-    
-    if sizeCache.implementsWidthDelegate {
-      if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
-        let from = layoutAttributes[currentIndexPath] {
-        if upcomingPagingItem > state.currentPagingItem {
-          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
-          let fromDiff = from.frame.width - fromWidth
-          distance -= fromDiff
-        }
-      }
-    }
-    return distance
-  }
-  
-  private func distanceToRightAlignedItem() -> CGFloat {
-    guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
-      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
-    
-    let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
-    let currentPosition = to.frame.origin.x + to.frame.width
-    let width = view.contentOffset.x + view.bounds.width
-    var distance = currentPosition - width
-    
-    if sizeCache.implementsWidthDelegate {
-      if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
-        let from = layoutAttributes[currentIndexPath] {
-        if upcomingPagingItem < state.currentPagingItem {
-          let toDiff = toWidth - to.frame.width
-          distance += toDiff
-        } else {
-          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
-          let fromDiff = from.frame.width - fromWidth
-          let toDiff = toWidth - to.frame.width
-          distance -= fromDiff
-          distance += toDiff
-        }
-      } else {
-        distance += toWidth - to.frame.width
-      }
-    }
-    
-    return distance
-  }
-  
-  private func distanceToCenteredItem() -> CGFloat {
-    guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
-      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
-    
-    let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
-    var distance = to.frame.midX - view.bounds.midX
-    
-    if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
-      let from = layoutAttributes[currentIndexPath] {
-      
-      let distanceToCenter = view.bounds.midX - from.frame.midX
-      let distanceBetweenCells = to.frame.midX - from.frame.midX
-      distance = distanceBetweenCells - distanceToCenter
-      
-      if sizeCache.implementsWidthDelegate {
-        let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
-        
-        if upcomingPagingItem < state.currentPagingItem {
-          distance = -(to.frame.width + (from.frame.midX - to.frame.maxX) - (toWidth / 2)) - distanceToCenter
-        } else {
-          let toDiff = (toWidth - to.frame.width) / 2
-          distance = fromWidth + (to.frame.midX - from.frame.maxX) + toDiff - (from.frame.width / 2) - distanceToCenter
-        }
-      }
-    } else if sizeCache.implementsWidthDelegate {
-      let toDiff = toWidth - to.frame.width
-      distance += toDiff / 2
-    }
-    
-    return distance
-  }
   
   private func createLayoutAttributes() {
     guard let state = state else { return }

--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -21,7 +21,6 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   var state: PagingState<T>?
   var dataStructure: PagingDataStructure<T>
   var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] = [:]
-  var currentTransition: PagingTransition? = nil
   
   open override var collectionViewContentSize: CGSize {
     return contentSize

--- a/Parchment/Classes/PagingInvalidationContext.swift
+++ b/Parchment/Classes/PagingInvalidationContext.swift
@@ -1,7 +1,5 @@
 import UIKit
 
 open class PagingInvalidationContext: UICollectionViewLayoutInvalidationContext {
-  var invalidateContentOffset: Bool = false
-  var invalidateTransition: Bool = false
   var invalidateSizes: Bool = false
 }

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -78,7 +78,6 @@ open class PagingViewController<T: PagingItem>:
   fileprivate var didLayoutSubviews: Bool = false
   fileprivate let sizeCache: PagingSizeCache<T>
   fileprivate var dataStructure: PagingDataStructure<T>
-  fileprivate var currentTransition: PagingTransition? = nil
   
   fileprivate var stateMachine: PagingStateMachine<T>? {
     didSet {
@@ -286,29 +285,10 @@ open class PagingViewController<T: PagingItem>:
       let invalidationContext = PagingInvalidationContext()
       
       // We don't want to update the content offset if there is no
-      // upcoming item to scroll to. We need to invalidate the layout
-      // though in order to update the layout attributes for the
+      // upcoming item to scroll to. We stil need to invalidate the
+      // layout in order to update the layout attributes for the
       // decoration views.
-      if let upcomingPagingItem = state.upcomingPagingItem {
-        
-        // When the old state is .selected it means that the user
-        // just started scrolling.
-        if case .selected = oldState {
-          invalidateTransition()
-
-          // Stop any ongoing scrolling so that the isDragging
-          // property is set to false in case the collection
-          // view is still scrolling after a swipe.
-          stopScrolling()
-          
-          // If the upcoming item is outside the currently visible
-          // items we need to append the items that are around the
-          // upcoming item so we can animate the transition.
-          if dataStructure.visibleItems.contains(upcomingPagingItem) == false {
-            reloadItems(around: upcomingPagingItem, keepExisting: true)
-          }
-        }
-        
+      if state.upcomingPagingItem != nil {
         invalidateContentOffset()
         
         if sizeCache.implementsWidthDelegate {
@@ -316,11 +296,7 @@ open class PagingViewController<T: PagingItem>:
         }
       }
       
-      // We don't want to update the content offset while the
-      // user is dragging in the collection view.
-      if collectionView.isDragging == false {
-        collectionViewLayout.invalidateLayout(with: invalidationContext)
-      }
+      collectionViewLayout.invalidateLayout(with: invalidationContext)
     }
   }
   
@@ -345,60 +321,21 @@ open class PagingViewController<T: PagingItem>:
       animated: animated,
       scrollPosition: scrollPosition)
   }
-  
-  fileprivate func invalidateTransition() {
-    guard let state = stateMachine?.state else { return }
-    
-    let distance = PagingDistance(
-      view: collectionView,
-      state: state,
-      dataStructure: dataStructure,
-      sizeCache: sizeCache,
-      selectedScrollPosition: options.selectedScrollPosition,
-      layoutAttributes: collectionViewLayout.layoutAttributes)
-    
-    currentTransition = PagingTransition(
-      contentOffset: collectionView.contentOffset,
-      distance: distance.calculate())
-  }
-  
+
   fileprivate func invalidateContentOffset() {
     guard let state = stateMachine?.state else { return }
-    
     if options.menuTransition == .scrollAlongside {
-      if let transition = currentTransition {
+      if case let .scrolling(_, _, progress, initialContentOffset, distance) = state {
         if collectionView.contentSize.width >= collectionView.bounds.width && state.progress != 0 {
           let contentOffset = CGPoint(
-            x: transition.contentOffset.x + (transition.distance * fabs(state.progress)),
-            y: transition.contentOffset.y)
+            x: initialContentOffset.x + (distance * fabs(progress)),
+            y: initialContentOffset.y)
           
           // We need to use setContentOffset with no animation in
           // order to stop any ongoing scroll.
           collectionView.setContentOffset(contentOffset, animated: false)
         }
       }
-    }
-  }
-  
-  // The content offset and distance between items can change while a
-  // transition is in progress meaning the current transition will be
-  // wrong. For instance, when hitting the edge of the collection view
-  // while transitioning we need to reload all the paging items and
-  // update the transition data.
-  fileprivate func updateCurrentTransition() {
-    let oldTransition = currentTransition
-    invalidateTransition()
-    
-    if let oldTransition = oldTransition,
-      let newTransition = currentTransition {
-      
-      let contentOffset = CGPoint(
-        x: collectionView.contentOffset.x - (oldTransition.distance - newTransition.distance),
-        y: collectionView.contentOffset.y)
-      
-      currentTransition = PagingTransition(
-        contentOffset: contentOffset,
-        distance: oldTransition.distance)
     }
   }
   
@@ -492,13 +429,16 @@ open class PagingViewController<T: PagingItem>:
       x: oldContentOffset.x - offset,
       y: oldContentOffset.y)
     
-    // Update the transition state for the layout in case there is
-    // already a transition in progress.
-    updateCurrentTransition()
-    
     // We need to perform layout here, if not the collection view
     // seems to get in a weird state.
     collectionView.layoutIfNeeded()
+    
+    // The content offset and distance between items can change while a
+    // transition is in progress meaning the current transition will be
+    // wrong. For instance, when hitting the edge of the collection view
+    // while transitioning we need to reload all the paging items and
+    // update the transition data.
+    stateMachine?.fire(.reload(contentOffset: collectionView.contentOffset))
   }
   
   fileprivate func selectViewController(_ pagingItem: T, direction: PagingDirection, animated: Bool = true) {
@@ -641,6 +581,34 @@ open class PagingViewController<T: PagingItem>:
   }
   
   // MARK: PagingStateMachineDelegate
+  
+  func pagingStateMachine<U>(_ pagingStateMachine: PagingStateMachine<U>, transitionFromPagingItem currentPagingItem: U, toPagingItem upcomingPagingItem: U?) -> PagingTransition {
+    guard
+      let currentPagingItem = currentPagingItem as? T,
+      let upcomingPagingItem = upcomingPagingItem as? T else {
+      return PagingTransition(contentOffset: .zero, distance: 0)
+    }
+    
+    // If the upcoming item is outside the currently visible
+    // items we need to append the items that are around the
+    // upcoming item so we can animate the transition.
+    if dataStructure.visibleItems.contains(upcomingPagingItem) == false {
+      reloadItems(around: upcomingPagingItem, keepExisting: true)
+    }
+    
+    let distance = PagingDistance(
+      view: collectionView,
+      currentPagingItem: currentPagingItem,
+      upcomingPagingItem: upcomingPagingItem,
+      dataStructure: dataStructure,
+      sizeCache: sizeCache,
+      selectedScrollPosition: options.selectedScrollPosition,
+      layoutAttributes: collectionViewLayout.layoutAttributes)
+    
+    return PagingTransition(
+      contentOffset: collectionView.contentOffset,
+      distance: distance.calculate())
+  }
   
   func pagingStateMachine<U>(_ pagingStateMachine: PagingStateMachine<U>, pagingItemBeforePagingItem pagingItem: U) -> U? {
     guard let pagingItem = pagingItem as? T else { return nil }

--- a/Parchment/Enums/InvalidationSummary.swift
+++ b/Parchment/Enums/InvalidationSummary.swift
@@ -10,8 +10,6 @@ enum InvalidationSummary {
   case partial
   case everything
   case dataSourceCounts
-  case contentOffset
-  case transition
   case sizes
   
   init(_ invalidationContext: UICollectionViewLayoutInvalidationContext) {
@@ -20,12 +18,8 @@ enum InvalidationSummary {
     } else if invalidationContext.invalidateDataSourceCounts {
       self = .dataSourceCounts
     } else if let context = invalidationContext as? PagingInvalidationContext {
-      if context.invalidateTransition {
-        self = .transition
-      } else if context.invalidateSizes {
+      if context.invalidateSizes {
         self = .sizes
-      } else if context.invalidateContentOffset {
-        self = .contentOffset
       } else {
         self = .partial
       }
@@ -44,10 +38,6 @@ enum InvalidationSummary {
       return .dataSourceCounts
     case (.sizes, _), (_, .sizes):
       return .sizes
-    case (.transition, _), (_, .transition):
-      return .transition
-    case (.contentOffset, _), (_, .contentOffset):
-      return .contentOffset
     case (.partial, _), (_, .partial):
       return .partial
     default:

--- a/Parchment/Enums/PagingEvent.swift
+++ b/Parchment/Enums/PagingEvent.swift
@@ -6,6 +6,7 @@ enum PagingEvent<T: PagingItem> where T: Equatable {
   case finishScrolling
   case transitionSize
   case cancelScrolling
+  case reload(contentOffset: CGPoint)
 }
 
 extension PagingEvent {

--- a/Parchment/Enums/PagingState.swift
+++ b/Parchment/Enums/PagingState.swift
@@ -5,14 +5,16 @@ enum PagingState<T: PagingItem>: Equatable where T: Equatable {
   case scrolling(
     pagingItem: T,
     upcomingPagingItem: T?,
-    progress: CGFloat)
+    progress: CGFloat,
+    initialContentOffset: CGPoint,
+    distance: CGFloat)
 }
 
 extension PagingState {
   
   var currentPagingItem: T {
     switch self {
-    case let .scrolling(pagingItem, _, _):
+    case let .scrolling(pagingItem, _, _, _, _):
       return pagingItem
     case let .selected(pagingItem):
       return pagingItem
@@ -21,7 +23,7 @@ extension PagingState {
   
   var upcomingPagingItem: T? {
     switch self {
-    case let .scrolling(_, upcomingPagingItem, _):
+    case let .scrolling(_, upcomingPagingItem, _, _, _):
       return upcomingPagingItem
     case .selected:
       return nil
@@ -30,14 +32,23 @@ extension PagingState {
   
   var progress: CGFloat {
     switch self {
-    case let .scrolling(_, _, progress):
+    case let .scrolling(_, _, progress, _, _):
       return progress
     case .selected:
       return 0
     }
   }
   
-  var visuallySelectedPagingItem: T {
+  var distance: CGFloat {
+    switch self {
+    case let .scrolling(_, _, _, _, distance):
+      return distance
+    case .selected:
+      return 0
+    }
+  }
+  
+  var visuallySelectedPagingItem: T? {
     if fabs(progress) > 0.5 {
       return upcomingPagingItem ?? currentPagingItem
     } else {
@@ -49,11 +60,16 @@ extension PagingState {
 
 func ==<T>(lhs: PagingState<T>, rhs: PagingState<T>) -> Bool {
   switch (lhs, rhs) {
-  case (let .scrolling(a, b, c), let .scrolling(w, x, y)):
-    if a == w && c == y {
-      if let b = b, let x = x, b == x {
+  case
+    (let .scrolling(lhsCurrent, lhsUpcoming, lhsProgress, lhsOffset, lhsDistance),
+     let .scrolling(rhsCurrent, rhsUpcoming, rhsProgress, rhsOffset, rhsDistance)):
+    if lhsCurrent == rhsCurrent &&
+      lhsProgress == rhsProgress &&
+      lhsOffset == rhsOffset &&
+      lhsDistance == rhsDistance {
+      if let lhsUpcoming = lhsUpcoming, let rhsUpcoming = rhsUpcoming, lhsUpcoming == rhsUpcoming {
         return true
-      } else if b == nil && x == nil {
+      } else if lhsUpcoming == nil && rhsUpcoming == nil {
         return true
       }
     }

--- a/Parchment/Structs/PagingDistance.swift
+++ b/Parchment/Structs/PagingDistance.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
+  
+  let view: UIScrollView
+  let state: PagingState<T>?
+  let dataStructure: PagingDataStructure<T>
+  let sizeCache: PagingSizeCache<T>
+  let selectedScrollPosition: PagingSelectedScrollPosition
+  let layoutAttributes: [IndexPath: PagingCellLayoutAttributes]
+  
+  /// In order to get the menu items to scroll alongside the content
+  /// we create a transition struct to keep track of the initial
+  /// content offset and the distance to the upcoming item so that we
+  /// can update the content offset as the user is swiping.
+  func calculate() -> CGFloat {
+    guard
+      let state = state,
+      let upcomingPagingItem = state.upcomingPagingItem,
+      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
+      let to = layoutAttributes[upcomingIndexPath] else {
+        
+        // When there is no upcomingIndexPath or any layout attributes
+        // for that item we have no way to determine the distance.
+        return 0
+    }
+    
+    var distance: CGFloat = 0
+    
+    switch (selectedScrollPosition) {
+    case .left:
+      distance = distanceLeft()
+    case .right:
+      distance = distanceRight()
+    case .preferCentered:
+      distance = distanceCentered()
+    }
+    
+    // Update the distance to account for cases where the user has
+    // scrolled all the way over to the other edge.
+    if view.near(edge: .left, clearance: -distance) && distance < 0 && dataStructure.hasItemsBefore == false {
+      distance = -(view.contentOffset.x + view.contentInset.left)
+    } else if view.near(edge: .right, clearance: distance) && distance > 0 &&
+      dataStructure.hasItemsAfter == false {
+      
+      distance = view.contentSize.width - (view.contentOffset.x + view.bounds.width)
+      
+      if sizeCache.implementsWidthDelegate {
+        let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
+        distance += toWidth - to.frame.width
+        
+        if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+          let from = layoutAttributes[currentIndexPath] {
+          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+          distance -= from.frame.width - fromWidth
+        }
+        
+        // If the selected cells grows so much that it will move
+        // beyond the center of the view, we want to update the
+        // distance after all.
+        if selectedScrollPosition == .preferCentered {
+          let center = view.bounds.midX
+          let centerAfterTransition = to.frame.midX - distance
+          if centerAfterTransition < center {
+            distance = view.contentSize.width - (view.contentOffset.x + view.bounds.width)
+          }
+        }
+      }
+    }
+    
+    return distance
+  }
+  
+  private func distanceLeft() -> CGFloat {
+    guard
+      let state = state,
+      let upcomingPagingItem = state.upcomingPagingItem,
+      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
+      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
+    
+    var distance = to.center.x - (to.bounds.width / 2) - view.contentOffset.x
+    
+    if sizeCache.implementsWidthDelegate {
+      if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+        let from = layoutAttributes[currentIndexPath] {
+        if upcomingPagingItem > state.currentPagingItem {
+          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+          let fromDiff = from.frame.width - fromWidth
+          distance -= fromDiff
+        }
+      }
+    }
+    return distance
+  }
+  
+  private func distanceRight() -> CGFloat {
+    guard
+      let state = state,
+      let upcomingPagingItem = state.upcomingPagingItem,
+      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
+      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
+    
+    let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
+    let currentPosition = to.frame.origin.x + to.frame.width
+    let width = view.contentOffset.x + view.bounds.width
+    var distance = currentPosition - width
+    
+    if sizeCache.implementsWidthDelegate {
+      if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+        let from = layoutAttributes[currentIndexPath] {
+        if upcomingPagingItem < state.currentPagingItem {
+          let toDiff = toWidth - to.frame.width
+          distance += toDiff
+        } else {
+          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+          let fromDiff = from.frame.width - fromWidth
+          let toDiff = toWidth - to.frame.width
+          distance -= fromDiff
+          distance += toDiff
+        }
+      } else {
+        distance += toWidth - to.frame.width
+      }
+    }
+    
+    return distance
+  }
+  
+  private func distanceCentered() -> CGFloat {
+    guard
+      let state = state,
+      let upcomingPagingItem = state.upcomingPagingItem,
+      let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
+      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
+    
+    let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
+    var distance = to.frame.midX - view.bounds.midX
+    
+    if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+      let from = layoutAttributes[currentIndexPath] {
+      
+      let distanceToCenter = view.bounds.midX - from.frame.midX
+      let distanceBetweenCells = to.frame.midX - from.frame.midX
+      distance = distanceBetweenCells - distanceToCenter
+      
+      if sizeCache.implementsWidthDelegate {
+        let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+        
+        if upcomingPagingItem < state.currentPagingItem {
+          distance = -(to.frame.width + (from.frame.midX - to.frame.maxX) - (toWidth / 2)) - distanceToCenter
+        } else {
+          let toDiff = (toWidth - to.frame.width) / 2
+          distance = fromWidth + (to.frame.midX - from.frame.maxX) + toDiff - (from.frame.width / 2) - distanceToCenter
+        }
+      }
+    } else if sizeCache.implementsWidthDelegate {
+      let toDiff = toWidth - to.frame.width
+      distance += toDiff / 2
+    }
+    
+    return distance
+  }
+}

--- a/Parchment/Structs/PagingDistance.swift
+++ b/Parchment/Structs/PagingDistance.swift
@@ -3,7 +3,8 @@ import Foundation
 struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
   
   let view: UIScrollView
-  let state: PagingState<T>?
+  let currentPagingItem: T
+  let upcomingPagingItem: T
   let dataStructure: PagingDataStructure<T>
   let sizeCache: PagingSizeCache<T>
   let selectedScrollPosition: PagingSelectedScrollPosition
@@ -15,8 +16,6 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
   /// can update the content offset as the user is swiping.
   func calculate() -> CGFloat {
     guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
       let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
       let to = layoutAttributes[upcomingIndexPath] else {
         
@@ -49,9 +48,9 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
         let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
         distance += toWidth - to.frame.width
         
-        if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+        if let currentIndexPath = dataStructure.indexPathForPagingItem(currentPagingItem),
           let from = layoutAttributes[currentIndexPath] {
-          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+          let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
           distance -= from.frame.width - fromWidth
         }
         
@@ -73,18 +72,16 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
   
   private func distanceLeft() -> CGFloat {
     guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
       let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
       let to = layoutAttributes[upcomingIndexPath] else { return 0 }
     
     var distance = to.center.x - (to.bounds.width / 2) - view.contentOffset.x
     
     if sizeCache.implementsWidthDelegate {
-      if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+      if let currentIndexPath = dataStructure.indexPathForPagingItem(currentPagingItem),
         let from = layoutAttributes[currentIndexPath] {
-        if upcomingPagingItem > state.currentPagingItem {
-          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+        if upcomingPagingItem > currentPagingItem {
+          let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
           let fromDiff = from.frame.width - fromWidth
           distance -= fromDiff
         }
@@ -95,8 +92,6 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
   
   private func distanceRight() -> CGFloat {
     guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
       let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
       let to = layoutAttributes[upcomingIndexPath] else { return 0 }
     
@@ -106,13 +101,13 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
     var distance = currentPosition - width
     
     if sizeCache.implementsWidthDelegate {
-      if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+      if let currentIndexPath = dataStructure.indexPathForPagingItem(currentPagingItem),
         let from = layoutAttributes[currentIndexPath] {
-        if upcomingPagingItem < state.currentPagingItem {
+        if upcomingPagingItem < currentPagingItem {
           let toDiff = toWidth - to.frame.width
           distance += toDiff
         } else {
-          let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+          let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
           let fromDiff = from.frame.width - fromWidth
           let toDiff = toWidth - to.frame.width
           distance -= fromDiff
@@ -128,15 +123,13 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
   
   private func distanceCentered() -> CGFloat {
     guard
-      let state = state,
-      let upcomingPagingItem = state.upcomingPagingItem,
       let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem),
       let to = layoutAttributes[upcomingIndexPath] else { return 0 }
     
     let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
     var distance = to.frame.midX - view.bounds.midX
     
-    if let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem),
+    if let currentIndexPath = dataStructure.indexPathForPagingItem(currentPagingItem),
       let from = layoutAttributes[currentIndexPath] {
       
       let distanceToCenter = view.bounds.midX - from.frame.midX
@@ -144,9 +137,9 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
       distance = distanceBetweenCells - distanceToCenter
       
       if sizeCache.implementsWidthDelegate {
-        let fromWidth = sizeCache.itemWidth(for: state.currentPagingItem)
+        let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
         
-        if upcomingPagingItem < state.currentPagingItem {
+        if upcomingPagingItem < currentPagingItem {
           distance = -(to.frame.width + (from.frame.midX - to.frame.maxX) - (toWidth / 2)) - distanceToCenter
         } else {
           let toDiff = (toWidth - to.frame.width) / 2

--- a/ParchmentTests/PagingStateMachineSpec.swift
+++ b/ParchmentTests/PagingStateMachineSpec.swift
@@ -24,6 +24,11 @@ private func beSelected() -> MatcherFunc<PagingState<Item>> {
 }
 
 private class Delegate: PagingStateMachineDelegate {
+  func pagingStateMachine<T>(
+    _ pagingStateMachine: PagingStateMachine<T>,
+    transitionFromPagingItem: T, toPagingItem: T?) -> PagingTransition {
+    return PagingTransition(contentOffset: .zero, distance: 0)
+  }
   
   func pagingStateMachine<T>(
     _ pagingStateMachine: PagingStateMachine<T>,
@@ -72,7 +77,9 @@ class PagingStateMachineSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              progress: 0.5)
+              progress: 0.5,
+              initialContentOffset: .zero,
+              distance: 0)
             stateMachine = PagingStateMachine(initialState: state)
           }
           
@@ -94,7 +101,9 @@ class PagingStateMachineSpec: QuickSpec {
               let state: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: nil,
-                progress: 0.5)
+                progress: 0.5,
+                initialContentOffset: .zero,
+                distance: 0)
               stateMachine = PagingStateMachine(initialState: state)
             }
             
@@ -124,7 +133,9 @@ class PagingStateMachineSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              progress: 0.5)
+              progress: 0.5,
+              initialContentOffset: .zero,
+              distance: 0)
             stateMachine = PagingStateMachine(initialState: state)
           }
           
@@ -153,7 +164,9 @@ class PagingStateMachineSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              progress: 0.5)
+              progress: 0.5,
+              initialContentOffset: .zero,
+              distance: 0)
             stateMachine = PagingStateMachine(initialState: state)
           }
           
@@ -170,13 +183,19 @@ class PagingStateMachineSpec: QuickSpec {
         
         describe("selected paging item is not equal current item") {
           
+          beforeEach {
+            stateMachine.delegate = stateMachineDelegate
+          }
+          
           describe("is in the scrolling state") {
             it("does not change the state") {
               
               let state: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: nil,
-                progress: 0)
+                progress: 0,
+                initialContentOffset: .zero,
+                distance: 0)
               
               stateMachine = PagingStateMachine(initialState: state)
               
@@ -292,6 +311,7 @@ class PagingStateMachineSpec: QuickSpec {
         }
         
         it("sets the new progress") {
+          stateMachine.delegate = stateMachineDelegate
           stateMachine.fire(.scroll(progress: 0.5))
           expect(stateMachine.state.progress).to(equal(0.5))
         }
@@ -303,7 +323,9 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: 0.1)
+                progress: 0.1,
+                initialContentOffset: .zero,
+                distance: 0)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: -0.1))
               expect(stateMachine.state).to(beSelected())
@@ -316,7 +338,9 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: -0.1)
+                progress: -0.1,
+                initialContentOffset: .zero,
+                distance: 0)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state).to(beSelected())
@@ -330,7 +354,9 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: 0.5)
+                progress: 0.5,
+                initialContentOffset: .zero,
+                distance: 0)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: 0))
               expect(stateMachine.state).to(beSelected())
@@ -340,7 +366,9 @@ class PagingStateMachineSpec: QuickSpec {
               let initialState: PagingState = .scrolling(
                 pagingItem: Item(index: 0),
                 upcomingPagingItem: Item(index: 1),
-                progress: 0)
+                progress: 0,
+                initialContentOffset: .zero,
+                distance: 0)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: 0.1))
               expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: 1)))

--- a/ParchmentTests/PagingStateSpec.swift
+++ b/ParchmentTests/PagingStateSpec.swift
@@ -15,7 +15,9 @@ class PagingStateSpec: QuickSpec {
           let state: PagingState = .scrolling(
             pagingItem: Item(index: 0),
             upcomingPagingItem: Item(index: 1),
-            progress: 0)
+            progress: 0,
+            initialContentOffset: .zero,
+            distance: 0)
           expect(state.currentPagingItem).to(equal(Item(index: 0)))
         }
         
@@ -23,7 +25,9 @@ class PagingStateSpec: QuickSpec {
           let state: PagingState = .scrolling(
             pagingItem: Item(index: 0),
             upcomingPagingItem: Item(index: 1),
-            progress: 0.5)
+            progress: 0.5,
+            initialContentOffset: .zero,
+            distance: 0)
           expect(state.progress).to(equal(0.5))
         }
         
@@ -33,7 +37,9 @@ class PagingStateSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: Item(index: 1),
-              progress: 0)
+              progress: 0,
+              initialContentOffset: .zero,
+              distance: 0)
             expect(state.upcomingPagingItem).to(equal(Item(index: 1)))
           }
           
@@ -44,7 +50,9 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: Item(index: 1),
-                  progress: 0.6)
+                  progress: 0.6,
+                  initialContentOffset: .zero,
+                  distance: 0)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 1)))
               }
             }
@@ -54,7 +62,9 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: Item(index: 1),
-                  progress: 0.3)
+                  progress: 0.3,
+                  initialContentOffset: .zero,
+                  distance: 0)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }
@@ -69,7 +79,9 @@ class PagingStateSpec: QuickSpec {
             let state: PagingState = .scrolling(
               pagingItem: Item(index: 0),
               upcomingPagingItem: nil,
-              progress: 0)
+              progress: 0,
+              initialContentOffset: .zero,
+              distance: 0)
             expect(state.upcomingPagingItem).to(beNil())
           }
           
@@ -80,7 +92,9 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: nil,
-                  progress: 0.6)
+                  progress: 0.6,
+                  initialContentOffset: .zero,
+                  distance: 0)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }
@@ -90,7 +104,9 @@ class PagingStateSpec: QuickSpec {
                 let state: PagingState = .scrolling(
                   pagingItem: Item(index: 0),
                   upcomingPagingItem: nil,
-                  progress: 0.3)
+                  progress: 0.3,
+                  initialContentOffset: .zero,
+                  distance: 0)
                 expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
               }
             }


### PR DESCRIPTION
When updating the content offset while scrolling relatively fast the
menu items would sometimes lag behind. This was mostly visible in
performance heavy situations, like when using the width delegate
alongside some resource heavy view controllers. Moving the content
offset invalidation out of the collection view layout fixes this issue.

With these changes, the invalidation context is only used to update
the layout attributes, and not to calculate the distance to the next
item or to update the content offset. The PagingViewController is now
responsible for updating the content offset, while the distance
calculation is moved into its own separate struct. This also makes the
distance calculation much easier to test.