### PR TITLE
Add initial state to PagingState

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -19,6 +19,12 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   UICollectionViewLayout, PagingLayout where T: Hashable, T: Comparable {
   
   public let options: PagingOptions
+  
+  /// The current state of the menu items. Indicates whether an item
+  /// is currently selected or is scrolling to another item. Can be
+  /// used to get the distance and progress of any ongoing transition.
+  public var state: PagingState<T> = .empty
+  
   public var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] = [:]
   public var indicatorLayoutAttributes: PagingIndicatorLayoutAttributes?
   public var borderLayoutAttributes: PagingBorderLayoutAttributes?
@@ -32,7 +38,6 @@ open class PagingCollectionViewLayout<T: PagingItem>:
     return PagingCellLayoutAttributes.self
   }
   
-  var state: PagingState<T> = .empty
   var dataStructure: PagingDataStructure<T>?
   var sizeCache: PagingSizeCache<T>?
   var contentInsets: UIEdgeInsets = .zero

--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -32,7 +32,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
     return PagingCellLayoutAttributes.self
   }
   
-  var state: PagingState<T>?
+  var state: PagingState<T> = .empty
   var dataStructure: PagingDataStructure<T>?
   var sizeCache: PagingSizeCache<T>?
   var contentInsets: UIEdgeInsets = .zero
@@ -156,7 +156,6 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   
   private func createLayoutAttributes() {
     guard
-      let state = state,
       let sizeCache = sizeCache,
       let dataStructure = dataStructure else { return }
     
@@ -289,9 +288,11 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   }
   
   private func updateIndicatorLayoutAttributes() {
-    guard let state = state, let dataStructure = dataStructure else { return }
+    guard
+      let currentPagingItem = state.currentPagingItem,
+      let dataStructure = dataStructure else { return }
     
-    let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem)
+    let currentIndexPath = dataStructure.indexPathForPagingItem(currentPagingItem)
     let upcomingIndexPath = upcomingIndexPathForIndexPath(currentIndexPath)
     
     if let upcomingIndexPath = upcomingIndexPath {
@@ -321,9 +322,12 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   }
   
   fileprivate func indicatorMetricForFirstItem() -> PagingIndicatorMetric? {
-    guard let state = state, let dataStructure = dataStructure else { return nil }
+    guard
+      let currentPagingItem = state.currentPagingItem,
+      let dataStructure = dataStructure else { return nil }
+    
     if let first = dataStructure.sortedItems.first {
-      if state.currentPagingItem < first {
+      if currentPagingItem < first {
         return PagingIndicatorMetric(
           frame: indicatorFrameForIndex(-1),
           insets: indicatorInsetsForIndex(-1),
@@ -334,9 +338,12 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   }
   
   fileprivate func indicatorMetricForLastItem() -> PagingIndicatorMetric? {
-    guard let state = state, let dataStructure = dataStructure else { return nil }
+    guard
+      let currentPagingItem = state.currentPagingItem,
+      let dataStructure = dataStructure else { return nil }
+    
     if let last = dataStructure.sortedItems.last {
-      if state.currentPagingItem > last {
+      if currentPagingItem > last {
         return PagingIndicatorMetric(
           frame: indicatorFrameForIndex(dataStructure.visibleItems.count),
           insets: indicatorInsetsForIndex(dataStructure.visibleItems.count),
@@ -347,9 +354,11 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   }
   
   fileprivate func progressForItem(at indexPath: IndexPath) -> CGFloat {
-    guard let state = state, let dataStructure = dataStructure else { return 0 }
+    guard
+      let currentPagingItem = state.currentPagingItem,
+      let dataStructure = dataStructure else { return 0 }
     
-    let currentIndexPath = dataStructure.indexPathForPagingItem(state.currentPagingItem)
+    let currentIndexPath = dataStructure.indexPathForPagingItem(currentPagingItem)
     
     if let currentIndexPath = currentIndexPath {
       if indexPath.item == currentIndexPath.item {
@@ -367,7 +376,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   }
   
   fileprivate func upcomingIndexPathForIndexPath(_ indexPath: IndexPath?) -> IndexPath? {
-    guard let state = state, let dataStructure = dataStructure else { return indexPath }
+    guard let dataStructure = dataStructure else { return indexPath }
     
     if let upcomingPagingItem = state.upcomingPagingItem, let upcomingIndexPath = dataStructure.indexPathForPagingItem(upcomingPagingItem) {
       return upcomingIndexPath
@@ -414,7 +423,6 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   
   fileprivate func frameForIndex(_ index: Int) -> CGRect {
     guard
-      let state = state,
       let sizeCache = sizeCache,
       let dataStructure = dataStructure,
       let attributes = layoutAttributes[IndexPath(item: index, section: 0)] else { return .zero }

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -167,7 +167,10 @@ open class PagingViewController<T: PagingItem>:
     set { options.theme.headerBackgroundColor = newValue }
   }
   
-  private var state: PagingState<T> = .empty
+  /// The current state of the menu items. Indicates whether an item
+  /// is currently selected or is scrolling to another item. Can be
+  /// used to get the distance and progress of any ongoing transition.
+  public private(set) var state: PagingState<T> = .empty
   
   /// The data source is responsible for providing the `PagingItem`s
   /// that are displayed in the menu. The `PagingItem` protocol is

--- a/Parchment/Enums/PagingState.swift
+++ b/Parchment/Enums/PagingState.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum PagingState<T: PagingItem>: Equatable where T: Equatable {
+  case empty
   case selected(pagingItem: T)
   case scrolling(
     pagingItem: T,
@@ -12,8 +13,10 @@ enum PagingState<T: PagingItem>: Equatable where T: Equatable {
 
 extension PagingState {
   
-  var currentPagingItem: T {
+  var currentPagingItem: T? {
     switch self {
+    case .empty:
+      return nil
     case let .scrolling(pagingItem, _, _, _, _):
       return pagingItem
     case let .selected(pagingItem):
@@ -23,6 +26,8 @@ extension PagingState {
   
   var upcomingPagingItem: T? {
     switch self {
+    case .empty:
+      return nil
     case let .scrolling(_, upcomingPagingItem, _, _, _):
       return upcomingPagingItem
     case .selected:
@@ -34,7 +39,7 @@ extension PagingState {
     switch self {
     case let .scrolling(_, _, progress, _, _):
       return progress
-    case .selected:
+    case .selected, .empty:
       return 0
     }
   }
@@ -43,7 +48,7 @@ extension PagingState {
     switch self {
     case let .scrolling(_, _, _, _, distance):
       return distance
-    case .selected:
+    case .selected, .empty:
       return 0
     }
   }
@@ -75,6 +80,8 @@ func ==<T>(lhs: PagingState<T>, rhs: PagingState<T>) -> Bool {
     }
     return false
   case (let .selected(a), let .selected(b)) where a == b:
+    return true
+  case (.empty, .empty):
     return true
   default:
     return false

--- a/Parchment/Enums/PagingState.swift
+++ b/Parchment/Enums/PagingState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum PagingState<T: PagingItem>: Equatable where T: Equatable {
+public enum PagingState<T: PagingItem>: Equatable where T: Equatable {
   case empty
   case selected(pagingItem: T)
   case scrolling(
@@ -11,7 +11,7 @@ enum PagingState<T: PagingItem>: Equatable where T: Equatable {
     distance: CGFloat)
 }
 
-extension PagingState {
+public extension PagingState {
   
   var currentPagingItem: T? {
     switch self {
@@ -63,7 +63,7 @@ extension PagingState {
   
 }
 
-func ==<T>(lhs: PagingState<T>, rhs: PagingState<T>) -> Bool {
+public func ==<T>(lhs: PagingState<T>, rhs: PagingState<T>) -> Bool {
   switch (lhs, rhs) {
   case
     (let .scrolling(lhsCurrent, lhsUpcoming, lhsProgress, lhsOffset, lhsDistance),


### PR DESCRIPTION
Adds an initial state called .empty that is used before any paging
items has been selected. This means the state no longer need to be
optional, which always felt a bit weird.