### PR TITLE
Clean up communication between internal classes

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 1.1.0
+github "Quick/Quick" ~> 1.2.0
 github "Quick/Nimble" "master"

--- a/Parchment/Classes/IndexedPagingDataSource.swift
+++ b/Parchment/Classes/IndexedPagingDataSource.swift
@@ -3,18 +3,22 @@ import Foundation
 class IndexedPagingDataSource<T: PagingItem>: PagingViewControllerInfiniteDataSource where T: Hashable & Comparable {
   
   let items: [T]
-  let viewControllerForIndex: (Int) -> UIViewController
+  var viewControllerForIndex: ((Int) -> UIViewController?)?
   
-  init(items: [T], viewControllerForIndex: @escaping (Int) -> UIViewController) {
+  init(items: [T]) {
     self.items = items
-    self.viewControllerForIndex = viewControllerForIndex
   }
   
   func pagingViewController<U>(_ pagingViewController: PagingViewController<U>, viewControllerForPagingItem item: U) -> UIViewController {
+    
     guard let index = items.index(of: item as! T) else {
       fatalError("pagingViewController:viewControllerForPagingItem: PagingItem does not exist")
     }
-    return viewControllerForIndex(index)
+    guard let viewController = viewControllerForIndex?(index) else {
+       fatalError("pagingViewController:viewControllerForPagingItem: No view controller exist for PagingItem")
+    }
+    
+    return viewController
   }
   
   func pagingViewController<U>(_ pagingViewController: PagingViewController<U>, pagingItemBeforePagingItem item: U) -> U? {

--- a/Parchment/Classes/PagingSizeCache.swift
+++ b/Parchment/Classes/PagingSizeCache.swift
@@ -3,7 +3,7 @@ import Foundation
 class PagingSizeCache<T: PagingItem>  where T: Hashable, T: Comparable {
   
   var implementsWidthDelegate: Bool = false
-  weak var delegate: PagingSizeCacheDelegate?
+  var widthForPagingItem: ((T, Bool) -> CGFloat?)?
   
   private let options: PagingOptions
   private var widthCache: [T: CGFloat] = [:]
@@ -36,7 +36,7 @@ class PagingSizeCache<T: PagingItem>  where T: Hashable, T: Comparable {
     if let width = widthCache[pagingItem] {
       return width
     } else {
-      let width = delegate?.pagingSizeCache(self, widthForPagingItem: pagingItem, isSelected: false)
+      let width = widthForPagingItem?(pagingItem, false)
       widthCache[pagingItem] = width
       return width ?? options.estimatedItemWidth
     }
@@ -46,7 +46,7 @@ class PagingSizeCache<T: PagingItem>  where T: Hashable, T: Comparable {
     if let width = selectedWidthCache[pagingItem] {
       return width
     } else {
-      let width = delegate?.pagingSizeCache(self, widthForPagingItem: pagingItem, isSelected: true)
+      let width = widthForPagingItem?(pagingItem, true)
       selectedWidthCache[pagingItem] = width
       return width ?? options.estimatedItemWidth
     }

--- a/Parchment/Classes/PagingStateMachine.swift
+++ b/Parchment/Classes/PagingStateMachine.swift
@@ -1,17 +1,12 @@
 import Foundation
 
-protocol PagingStateMachineDelegate: class {
-  func pagingStateMachine<T>(_ pagingStateMachine: PagingStateMachine<T>, pagingItemBeforePagingItem: T) -> T?
-  func pagingStateMachine<T>(_ pagingStateMachine: PagingStateMachine<T>, pagingItemAfterPagingItem: T) -> T?
-  func pagingStateMachine<T>(_ pagingStateMachine: PagingStateMachine<T>, transitionFromPagingItem: T, toPagingItem: T?) -> PagingTransition
-}
-
 class PagingStateMachine<T: PagingItem> where T: Equatable {
   
-  weak var delegate: PagingStateMachineDelegate?
-  
-  var didSelectPagingItem: ((T, PagingDirection, Bool) -> Void)?
-  var didChangeState: ((PagingState<T>, PagingState<T>, PagingEvent<T>?) -> Void)?
+  var onPagingItemSelect: ((T, PagingDirection, Bool) -> Void)?
+  var onStateChange: ((PagingState<T>, PagingState<T>, PagingEvent<T>?) -> Void)?
+  var pagingItemBeforeItem: ((T) -> T?)?
+  var pagingItemAfterItem: ((T) -> T?)?
+  var transitionFromItem: ((T, T?) -> PagingTransition)?
   
   fileprivate(set) var state: PagingState<T>
   
@@ -45,20 +40,20 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
   fileprivate func handleReloadEvent(contentOffset: CGPoint, _ event: PagingEvent<T>) {
     let oldState = state
     if case let .scrolling(pagingItem, upcomingPagingItem, progress, _, distance) = state {
-     if let transition = delegate?.pagingStateMachine(self, transitionFromPagingItem: pagingItem, toPagingItem: upcomingPagingItem) {
+      if let transition = transitionFromItem?(pagingItem, upcomingPagingItem) {
       
-      let newContentOffset = CGPoint(
-        x: contentOffset.x - (distance - transition.distance),
-        y: contentOffset.y)
-      
-      state = .scrolling(
-        pagingItem: pagingItem,
-        upcomingPagingItem: upcomingPagingItem,
-        progress: progress,
-        initialContentOffset: newContentOffset,
-        distance: distance)
-      
-      didChangeState?(oldState, state, event)
+        let newContentOffset = CGPoint(
+          x: contentOffset.x - (distance - transition.distance),
+          y: contentOffset.y)
+        
+        state = .scrolling(
+          pagingItem: pagingItem,
+          upcomingPagingItem: upcomingPagingItem,
+          progress: progress,
+          initialContentOffset: newContentOffset,
+          distance: distance)
+        
+        onStateChange?(oldState, state, event)
       }
     }
   }
@@ -85,16 +80,12 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
           initialContentOffset: initialContentOffset,
           distance: distance)
         
-        didChangeState?(oldState, state, event)
+        onStateChange?(oldState, state, event)
       }
     case let .selected(pagingItem):
       if progress > 0 {
-        let upcomingPagingItem = delegate?.pagingStateMachine(self, pagingItemAfterPagingItem: pagingItem)
-        
-        if let transition = delegate?.pagingStateMachine(self,
-          transitionFromPagingItem: pagingItem,
-          toPagingItem: upcomingPagingItem) {
-
+        let upcomingPagingItem = pagingItemAfterItem?(pagingItem)
+        if let transition = transitionFromItem?(pagingItem, upcomingPagingItem) {
           state = .scrolling(
             pagingItem: pagingItem,
             upcomingPagingItem: upcomingPagingItem,
@@ -102,25 +93,21 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
             initialContentOffset: transition.contentOffset,
             distance: transition.distance)
           
-          didChangeState?(oldState, state, event)
+          onStateChange?(oldState, state, event)
         }
       } else if progress < 0 {
-        let upcomingPagingItem = delegate?.pagingStateMachine(self, pagingItemBeforePagingItem: pagingItem)
-        
-        if let transition = delegate?.pagingStateMachine(self,
-          transitionFromPagingItem: pagingItem,
-          toPagingItem: upcomingPagingItem) {
-          
+        let upcomingPagingItem = pagingItemBeforeItem?(pagingItem)
+        if let transition = transitionFromItem?(pagingItem, upcomingPagingItem) {
           state = .scrolling(
             pagingItem: pagingItem,
             upcomingPagingItem: upcomingPagingItem,
             progress: progress,
             initialContentOffset: transition.contentOffset,
             distance: transition.distance)
+          
+          onStateChange?(oldState, state, event)
         }
       }
-      
-      didChangeState?(oldState, state, event)
     }
     
   }
@@ -131,15 +118,12 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
     switch state {
     case .empty:
       state = .selected(pagingItem: selectedPagingItem)
-      didChangeState?(oldState, state, event)
+      onStateChange?(oldState, state, event)
     default:
       if let currentPagingItem = state.currentPagingItem {
         if selectedPagingItem != state.currentPagingItem {
           if case .selected = state {
-            if let transition = delegate?.pagingStateMachine(self,
-              transitionFromPagingItem:
-              currentPagingItem, toPagingItem: selectedPagingItem) {
-              
+            if let transition = transitionFromItem?(currentPagingItem, selectedPagingItem) {
               state = .scrolling(
                 pagingItem: currentPagingItem,
                 upcomingPagingItem: selectedPagingItem,
@@ -147,8 +131,8 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
                 initialContentOffset: transition.contentOffset,
                 distance: transition.distance)
               
-              didSelectPagingItem?(selectedPagingItem, direction, animated)
-              didChangeState?(oldState, state, event)
+              onPagingItemSelect?(selectedPagingItem, direction, animated)
+              onStateChange?(oldState, state, event)
             }
           }
         }
@@ -161,7 +145,7 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
     switch state {
     case let .scrolling(currentPagingItem, upcomingPagingItem, _, _, _):
       state = .selected(pagingItem: upcomingPagingItem ?? currentPagingItem)
-      didChangeState?(oldState, state, event)
+      onStateChange?(oldState, state, event)
     case .selected, .empty:
       break
     }
@@ -172,7 +156,7 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
     switch state {
     case let .scrolling(currentPagingItem, _, _, _, _):
       state = .selected(pagingItem: currentPagingItem)
-      didChangeState?(oldState, state, event)
+      onStateChange?(oldState, state, event)
     case .selected, .empty:
       break
     }
@@ -183,7 +167,7 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
     switch state {
     case let .scrolling(currentPagingItem, _, _, _, _):
       state = .selected(pagingItem: currentPagingItem)
-      didChangeState?(oldState, state, event)
+      onStateChange?(oldState, state, event)
     case .selected, .empty:
       break
     }

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -30,47 +30,86 @@ class DataSource: PagingViewControllerInfiniteDataSource {
   
 }
 
+class DeinitPagingViewController: PagingViewController<PagingIndexItem> {
+  var deinitCalled: (() -> Void)?
+  deinit { deinitCalled?() }
+}
+
+class DeinitFixedPagingViewController: FixedPagingViewController {
+  var deinitCalled: (() -> Void)?
+  deinit { deinitCalled?() }
+}
+
 class PagingViewControllerSpec: QuickSpec {
   
   override func spec() {
     
-    let dataSource = DataSource()
-    var viewController: PagingViewController<Item>!
-    
-    beforeEach {
-      viewController = PagingViewController()
-      viewController.menuItemSize = .fixed(width: 100, height: 50)
-      viewController.infiniteDataSource = dataSource
-      
-      UIApplication.shared.keyWindow!.rootViewController = viewController
-      let _ = viewController.view
-      
-      viewController.collectionView!.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
-    }
-    
     describe("PagingViewController") {
       
-      it("reloadItems: at begining") {
-        viewController.select(pagingItem: Item(index: 0))
-        let items = viewController.collectionView!.numberOfItems(inSection: 0)
-        expect(items).to(equal(21))
+      describe("reloading items") {
+        
+        let dataSource = DataSource()
+        var viewController: PagingViewController<Item>!
+        
+        beforeEach {
+          viewController = PagingViewController()
+          viewController.menuItemSize = .fixed(width: 100, height: 50)
+          viewController.infiniteDataSource = dataSource
+          
+          UIApplication.shared.keyWindow!.rootViewController = viewController
+          let _ = viewController.view
+          
+          viewController.collectionView!.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
+        }
+        
+        it("reloadItems: at begining") {
+          viewController.select(pagingItem: Item(index: 0))
+          let items = viewController.collectionView!.numberOfItems(inSection: 0)
+          expect(items).to(equal(21))
+        }
+        
+        it("reloadItems: at center") {
+          viewController.select(pagingItem: Item(index: 20))
+          let items = viewController.collectionView!.numberOfItems(inSection: 0)
+          expect(items).to(equal(21))
+        }
+        
+        it("reloadItems: at end") {
+          viewController.select(pagingItem: Item(index: 50))
+          let items = viewController.collectionView!.numberOfItems(inSection: 0)
+          expect(items).to(equal(21))
+        }
+        
       }
       
-      it("reloadItems: at center") {
-        viewController.select(pagingItem: Item(index: 20))
-        let items = viewController.collectionView!.numberOfItems(inSection: 0)
-        expect(items).to(equal(21))
-      }
+      describe("retain cycles") {
       
-      it("reloadItems: at end") {
-        viewController.select(pagingItem: Item(index: 50))
-        let items = viewController.collectionView!.numberOfItems(inSection: 0)
-        expect(items).to(equal(21))
+        it("deinits PagingViewController") {
+          var instance: DeinitPagingViewController? = DeinitPagingViewController()
+          waitUntil { done in
+            instance?.deinitCalled = {
+              done()
+            }
+            DispatchQueue.global(qos: .background).async {
+              instance = nil
+            }
+          }
+        }
+        
+        it("deinits FixedPagingViewController") {
+          let viewController = UIViewController()
+          var instance: DeinitFixedPagingViewController? = DeinitFixedPagingViewController(viewControllers: [viewController])
+          waitUntil { done in
+            instance?.deinitCalled = {
+              done()
+            }
+            DispatchQueue.global(qos: .background).async {
+              instance = nil
+            }
+          }
+        }
       }
-      
     }
-    
   }
-  
 }
 


### PR DESCRIPTION
Use closures instead of delegates for both PagingStateMachine and
PagingSizeCache. Less boilerplate and works better with generics.

This also fixes some retain cycles that were introduced in the `1.0` branch.