### PR TITLE
Rename headerBackgroundColor to menuBackgroundColor

### DIFF
--- a/NavigationBarExample/ViewController.swift
+++ b/NavigationBarExample/ViewController.swift
@@ -38,7 +38,7 @@ class ViewController: UIViewController {
     super.viewDidLoad()
     
     pagingViewController.borderOptions = .hidden
-    pagingViewController.headerBackgroundColor = .clear
+    pagingViewController.menuBackgroundColor = .clear
     pagingViewController.indicatorColor = UIColor(white: 0, alpha: 0.4)
     pagingViewController.textColor = UIColor(white: 1, alpha: 0.6)
     pagingViewController.selectedTextColor = .white

--- a/Parchment/Classes/PagingOptions.swift
+++ b/Parchment/Classes/PagingOptions.swift
@@ -20,7 +20,7 @@ public class PagingOptions {
   public var selectedTextColor: UIColor
   public var backgroundColor: UIColor
   public var selectedBackgroundColor: UIColor
-  public var headerBackgroundColor: UIColor
+  public var menuBackgroundColor: UIColor
   public var borderColor: UIColor
   public var indicatorColor: UIColor
   
@@ -78,7 +78,7 @@ public class PagingOptions {
     selectedTextColor = UIColor(red: 3/255, green: 125/255, blue: 233/255, alpha: 1)
     backgroundColor = UIColor.white
     selectedBackgroundColor = .white
-    headerBackgroundColor = UIColor.white
+    menuBackgroundColor = UIColor.white
     borderColor = UIColor(white: 0.9, alpha: 1)
     indicatorColor = UIColor(red: 3/255, green: 125/255, blue: 233/255, alpha: 1)
   }

--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -33,7 +33,7 @@ open class PagingView: UIView {
     self.collectionView = collectionView
     self.pageView = pageView
     
-    collectionView.backgroundColor = options.headerBackgroundColor
+    collectionView.backgroundColor = options.menuBackgroundColor
     addSubview(pageView)
     addSubview(collectionView)
     setupConstraints()

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -177,10 +177,10 @@ open class PagingViewController<T: PagingItem>:
     set { options.selectedBackgroundColor = newValue }
   }
 
-  /// The background color for the header view behind the menu items.
-  public var headerBackgroundColor: UIColor {
-    get { return options.headerBackgroundColor }
-    set { options.headerBackgroundColor = newValue }
+  /// The background color for the view behind the menu items.
+  public var menuBackgroundColor: UIColor {
+    get { return options.menuBackgroundColor }
+    set { options.menuBackgroundColor = newValue }
   }
   
   /// The current state of the menu items. Indicates whether an item


### PR DESCRIPTION
We use the menu prefix for all other properties so it makes sense to
keep this consistent.