### PR TITLE
Add method for selecting items based on index

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -342,6 +342,21 @@ open class PagingViewController<T: PagingItem>:
         animated: animated))
     }
   }
+  
+  /// Selects the paging item at a given index. This can be called
+  /// both before and after the view has been loaded.
+  ///
+  /// - Parameter index: The index of the `PagingItem` to be displayed.
+  /// - Parameter animated: A boolean value that indicates whether
+  /// the transtion should be animated. Default is false.
+  open func select(index: Int, animated: Bool = false) {
+    guard let dataSource = dataSource else {
+      fatalError("select(index:animated:): You need to set the dataSource property to use this method")
+    }
+    
+    let pagingItem = dataSource.pagingViewController(self, pagingItemForIndex: index)
+    select(pagingItem: pagingItem, animated: animated)
+  }
 
   open override func loadView() {
     view = PagingView(options: options)


### PR DESCRIPTION
Throws a fatal error if you call this method without setting the
dataSource property, as we need the data source to get the correct
PagingItem for a given index.