### PR TITLE
Change collection view properties to non-optional

### DIFF
--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -10,15 +10,17 @@ import UIKit
 open class PagingView: UIView {
   
   open let options: PagingOptions
-  open var collectionView: UICollectionView?
-  open var pageView: UIView?
+  open let collectionView: UICollectionView
+  open let pageView: UIView
   
   /// Creates an instance of `PagingView`.
   ///
   /// - Parameter options: The `PagingOptions` passed into the
   /// `PagingViewController`.
-  public init(options: PagingOptions) {
+  public init(options: PagingOptions, collectionView: UICollectionView, pageView: UIView) {
     self.options = options
+    self.collectionView = collectionView
+    self.pageView = pageView
     super.init(frame: .zero)
   }
   
@@ -29,10 +31,7 @@ open class PagingView: UIView {
   /// Configures the view hierarchy, sets up the layout constraints
   /// and does any other customization based on the `PagingOptions`.
   /// Override this if you need any custom behavior.
-  open func configure(collectionView: UICollectionView, pageView: UIView) {
-    self.collectionView = collectionView
-    self.pageView = pageView
-    
+  open func configure() {
     collectionView.backgroundColor = options.menuBackgroundColor
     addSubview(pageView)
     addSubview(collectionView)
@@ -42,8 +41,6 @@ open class PagingView: UIView {
   /// Sets up all the layout constraints. Override this if you need to
   /// make changes to how the views are layed out.
   open func setupConstraints() {
-    guard let pageView = pageView, let collectionView = collectionView else { return }
-    
     collectionView.translatesAutoresizingMaskIntoConstraints = false
     pageView.translatesAutoresizingMaskIntoConstraints = false
     

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -59,24 +59,24 @@ class PagingViewControllerSpec: QuickSpec {
           UIApplication.shared.keyWindow!.rootViewController = viewController
           let _ = viewController.view
           
-          viewController.collectionView!.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
+          viewController.collectionView.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
         }
         
         it("reloadItems: at begining") {
           viewController.select(pagingItem: Item(index: 0))
-          let items = viewController.collectionView!.numberOfItems(inSection: 0)
+          let items = viewController.collectionView.numberOfItems(inSection: 0)
           expect(items).to(equal(21))
         }
         
         it("reloadItems: at center") {
           viewController.select(pagingItem: Item(index: 20))
-          let items = viewController.collectionView!.numberOfItems(inSection: 0)
+          let items = viewController.collectionView.numberOfItems(inSection: 0)
           expect(items).to(equal(21))
         }
         
         it("reloadItems: at end") {
           viewController.select(pagingItem: Item(index: 50))
-          let items = viewController.collectionView!.numberOfItems(inSection: 0)
+          let items = viewController.collectionView.numberOfItems(inSection: 0)
           expect(items).to(equal(21))
         }
         


### PR DESCRIPTION
When adding the menuLayoutClass property the collectionView and
collectionViewLayout properties was changed to optional since the
layout type can change after initialization.

Instead of changing the properties to optional we can initialize the
collection view with the default layout type when we create the
PagingViewController and then only re-create the layout if the
menuLayoutClass property changes. This means we can keep the collection
view and collection view layout non-optional, and it will also allow
you to change the layout type after the view has loaded.