### PR TITLE
Fix white background color on collection view

### DIFF
--- a/NavigationBarExample/ViewController.swift
+++ b/NavigationBarExample/ViewController.swift
@@ -45,6 +45,7 @@ class ViewController: UIViewController {
     pagingViewController.textColor = UIColor(white: 1, alpha: 0.6)
     pagingViewController.selectedTextColor = .white
     pagingViewController.backgroundColor = .clear
+    pagingViewController.selectedBackgroundColor = .clear
     
     // Make sure you add the PagingViewController as a child view
     // controller and contrain it to the edges of the view.

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -389,7 +389,6 @@ open class PagingViewController<T: PagingItem>:
     pageViewController.delegate = self
     pageViewController.dataSource = self
     
-    collectionView.backgroundColor = .white
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.delegate = self
     collectionView.dataSource = self


### PR DESCRIPTION
The collection view background color is configured using the
menuBackgroundColor option property in the PagingView, so we should not
override the color to white here.