### PR TITLE
Fix issue with menu items being clipped

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -76,9 +76,9 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   
   private var adjustedMenuInsets: UIEdgeInsets {
     return UIEdgeInsets(
-      top: options.menuInsets.top + safeAreaInsets.top,
+      top: options.menuInsets.top,
       left: options.menuInsets.left + safeAreaInsets.left,
-      bottom: options.menuInsets.bottom + safeAreaInsets.bottom,
+      bottom: options.menuInsets.bottom,
       right: options.menuInsets.right + safeAreaInsets.right)
   }
   


### PR DESCRIPTION
When using Parchment without a UINavigationController the menu items
would get clipped. This happened because we inset the menu items based
on the safe area insets, which gets a larger values when using without
a navigation controller. We only need to account for the safe area
insets horizontally so we can just remove the top and bottom insets.