### PR TITLE
Update default background color for menu items

### DIFF
--- a/NavigationBarExample/ViewController.swift
+++ b/NavigationBarExample/ViewController.swift
@@ -44,8 +44,6 @@ class ViewController: UIViewController {
     pagingViewController.indicatorColor = UIColor(white: 0, alpha: 0.4)
     pagingViewController.textColor = UIColor(white: 1, alpha: 0.6)
     pagingViewController.selectedTextColor = .white
-    pagingViewController.backgroundColor = .clear
-    pagingViewController.selectedBackgroundColor = .clear
     
     // Make sure you add the PagingViewController as a child view
     // controller and contrain it to the edges of the view.

--- a/Parchment/Classes/PagingOptions.swift
+++ b/Parchment/Classes/PagingOptions.swift
@@ -76,8 +76,8 @@ public class PagingOptions {
     font = UIFont.systemFont(ofSize: 15, weight: UIFont.Weight.medium)
     textColor = UIColor.black
     selectedTextColor = UIColor(red: 3/255, green: 125/255, blue: 233/255, alpha: 1)
-    backgroundColor = UIColor.white
-    selectedBackgroundColor = .white
+    backgroundColor = .clear
+    selectedBackgroundColor = .clear
     menuBackgroundColor = UIColor.white
     borderColor = UIColor(white: 0.9, alpha: 1)
     indicatorColor = UIColor(red: 3/255, green: 125/255, blue: 233/255, alpha: 1)


### PR DESCRIPTION
Change the default background color for menu items to
UIColor.clear. This means you don't have to update the menu item
color when changing the header background.