### PR TITLE
Fix integer overflow causing crash in UnplashExample

### DIFF
--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -13,14 +13,11 @@ struct ImageItem: PagingItem, Hashable, Comparable {
   let images: [UIImage]
   
   var hashValue: Int {
-    return title.hashValue + headerImage.hashValue
+    return index.hashValue &+ title.hashValue
   }
   
   static func ==(lhs: ImageItem, rhs: ImageItem) -> Bool {
-    return (
-      lhs.title == rhs.title &&
-        lhs.headerImage == rhs.headerImage &&
-        lhs.images == rhs.images)
+    return lhs.index == rhs.index && lhs.title == rhs.title
   }
   
   static func <(lhs: ImageItem, rhs: ImageItem) -> Bool {


### PR DESCRIPTION
The hashValue implementation in the UnplashExample target was
causing an integer overflow on older devices. Fixed by using the &+
operator to sum the hash values. This also updates the equatable
implementation to match on the same values as the hashValue.