### PR TITLE
Fix layout bug with cell heights when using width delegate

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -222,7 +222,7 @@ open class PagingCollectionViewLayout<T: PagingItem>:
           width = tween(from: width, to: selectedWidth, progress: abs(state.progress))
         }
         
-        attributes.frame = CGRect(x: x, y: y, width: width, height: options.menuHeight)
+        attributes.frame = CGRect(x: x, y: y, width: width, height: options.menuItemSize.height)
       } else {
         switch (options.menuItemSize) {
         case let .fixed(width, height):


### PR DESCRIPTION
When using the width delegate, the collection view layout would use
the computed property menuHeight when calculating the frame of the
cell. This property includes the menu insets, causing the cells to get
too large when using the menuInsets property alongside the width
delegate. Using the value of menuItemSize.height fixes this issue.