### PR TITLE
 Fix issues with reloading data

### DIFF
--- a/Parchment/Classes/EMPageViewController.swift
+++ b/Parchment/Classes/EMPageViewController.swift
@@ -220,6 +220,10 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
         self.removeChildIfNeeded(beforeViewController)
         self.removeChildIfNeeded(selectedViewController)
         self.removeChildIfNeeded(afterViewController)
+      
+        beforeViewController = nil
+        selectedViewController = nil
+        afterViewController = nil
     }
     
     /**

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -132,7 +132,7 @@ class PagingViewControllerSpec: QuickSpec {
           expect(viewController.state).to(equal(PagingState.selected(pagingItem: third)))
         }
         
-        fit("display an empty view after reloading data with no items") {
+        it("display an empty view after reloading data with no items") {
           dataSource.items = []
           viewController.reloadData()
           


### PR DESCRIPTION
The current implementation of reloadData was causing unexpected
results and would sometimes crash the application. This happened
because we were relying on the existing select method to reload
data. Instead we create a separate method that makes sure to reload
both the collection view and page view controller to the new state.

This also fixes an issue where you could swipe in the page view
controller after reloading data with no items (a5759ba)