### PR TITLE
Fix issue where willScrollToItem delegate was not called

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -1022,6 +1022,13 @@ open class PagingViewController<T: PagingItem>:
   }
   
   open func em_pageViewController(_ pageViewController: EMPageViewController, willStartScrollingFrom startingViewController: UIViewController, destinationViewController: UIViewController) {
+    if let upcomingPagingItem = state.upcomingPagingItem {
+      delegate?.pagingViewController(
+        self,
+        willScrollToItem: upcomingPagingItem,
+        startingViewController: startingViewController,
+        destinationViewController: destinationViewController)
+    }
     return
   }
   


### PR DESCRIPTION
When swiping between views the willScrollToItem got called correctly,
but not when  selecting items in the menu header.