### PR TITLE
Fix issue with indicator/border class was not registered

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -190,8 +190,11 @@ open class PagingCollectionViewLayout<T: PagingItem>:
     return layoutAttributes
   }
   
-  func registerDecorationViews() {
+  func registerIndicatorClass() {
     register(options.indicatorClass, forDecorationViewOfKind: PagingIndicatorKind)
+  }
+  
+  func registerBorderClass() {
     register(options.borderClass, forDecorationViewOfKind: PagingBorderKind)
   }
 

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -118,7 +118,10 @@ open class PagingViewController<T: PagingItem>:
   /// PagingIndicatorView.self_
   public var indicatorClass: PagingIndicatorView.Type {
     get { return options.indicatorClass }
-    set { options.indicatorClass = newValue }
+    set {
+      options.indicatorClass = newValue
+      collectionViewLayout.registerIndicatorClass()
+    }
   }
 
   /// Determine the color of the indicator view.
@@ -140,7 +143,10 @@ open class PagingViewController<T: PagingItem>:
   /// PagingBorderView.self_
   public var borderClass: PagingBorderView.Type {
     get { return options.borderClass }
-    set { options.borderClass = newValue }
+    set {
+      options.borderClass = newValue
+      collectionViewLayout.registerBorderClass()
+    }
   }
   
   /// Determine the color of the border view.
@@ -476,7 +482,8 @@ open class PagingViewController<T: PagingItem>:
     collectionViewLayout.visibleItems = visibleItems
     collectionViewLayout.sizeCache = sizeCache
     collectionViewLayout.state = state
-    collectionViewLayout.registerDecorationViews()
+    collectionViewLayout.registerIndicatorClass()
+    collectionViewLayout.registerBorderClass()
   }
   
   private func configureStateMachine() {


### PR DESCRIPTION
When overriding the borderClass or indicatorClass options, the classes
was not registered as decoration views on the collection view layout.