### PR TITLE
Fix reloading data when view controllers do not change

### DIFF
--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		3EADD99F1CC65C4D003171CF /* EMPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EADD99E1CC65C4D003171CF /* EMPageViewController.swift */; };
 		3EF3C1E31CA0870E00CDFE26 /* FixedPagingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EF3C1E21CA0870E00CDFE26 /* FixedPagingViewController.swift */; };
 		3EFEFBF71C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift */; };
+		951E163720A21D3A0055E9D4 /* PagingViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842601F4251F90072038C /* PagingViewControllerSpec.swift */; };
 		9525C63D1FEE6DDC00A18EA0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9525C63C1FEE6DDC00A18EA0 /* AppDelegate.swift */; };
 		9525C63F1FEE6DDC00A18EA0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9525C63E1FEE6DDC00A18EA0 /* ViewController.swift */; };
 		9525C6441FEE6DDC00A18EA0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9525C6431FEE6DDC00A18EA0 /* Assets.xcassets */; };
@@ -86,7 +87,6 @@
 		952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952D802E1E37CC09003DCB18 /* PagingTransition.swift */; };
 		954842591F42438E0072038C /* PagingInvalidationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842581F42438E0072038C /* PagingInvalidationContext.swift */; };
 		9548425D1F42486B0072038C /* PagingDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9548425C1F42486B0072038C /* PagingDiff.swift */; };
-		954842611F4251F90072038C /* PagingViewControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842601F4251F90072038C /* PagingViewControllerSpec.swift */; };
 		954842631F4252070072038C /* PagingDiffSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842621F4252070072038C /* PagingDiffSpec.swift */; };
 		954E7DEE1F48AE6E00342ECF /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954E7DEB1F48AE1300342ECF /* Item.swift */; };
 		955444B11FC99E2C001EC26B /* PagingSizeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 955444B01FC99E2C001EC26B /* PagingSizeCache.swift */; };
@@ -1161,9 +1161,9 @@
 				3E504EC71C7465B000AE1CE3 /* PagingStateMachineSpec.swift in Sources */,
 				3E5E93E91CE7E093000762A1 /* PagingDataStructureSpec.swift in Sources */,
 				3E5E93E31CE7D899000762A1 /* PagingStateSpec.swift in Sources */,
+				951E163720A21D3A0055E9D4 /* PagingViewControllerSpec.swift in Sources */,
 				954E7DEE1F48AE6E00342ECF /* Item.swift in Sources */,
 				954842631F4252070072038C /* PagingDiffSpec.swift in Sources */,
-				954842611F4251F90072038C /* PagingViewControllerSpec.swift in Sources */,
 				3EFEFBF71C80B8820023C949 /* PagingIndicatorLayoutAttributesSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Parchment/Classes/EMPageViewController.swift
+++ b/Parchment/Classes/EMPageViewController.swift
@@ -156,13 +156,13 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
     }()
     
     /// The view controller before the selected view controller.
-    private var beforeViewController: UIViewController?
+    var beforeViewController: UIViewController?
     
     /// The currently selected view controller. Can be `nil` if no view controller is selected.
     open private(set) var selectedViewController: UIViewController?
     
     /// The view controller after the selected view controller.
-    private var afterViewController: UIViewController?
+    var afterViewController: UIViewController?
     
     /// Boolean that indicates whether the page controller is currently in the process of scrolling.
     open private(set) var scrolling = false

--- a/Parchment/Classes/PagingStateMachine.swift
+++ b/Parchment/Classes/PagingStateMachine.swift
@@ -38,6 +38,8 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
       handleCancelScrollingEvent(event)
     case .removeAll:
       handleRemoveAllEvent(event)
+    case let .reset(pagingItem):
+      handleResetEvent(event, pagingItem: pagingItem)
     }
   }
   
@@ -184,6 +186,12 @@ class PagingStateMachine<T: PagingItem> where T: Equatable {
   private func handleRemoveAllEvent(_ event: PagingEvent<T>) {
     let oldState = state
     state = .empty
+    onStateChange?(oldState, state, event)
+  }
+  
+  private func handleResetEvent(_ event: PagingEvent<T>, pagingItem: T) {
+    let oldState = state
+    state = .selected(pagingItem: pagingItem)
     onStateChange?(oldState, state, event)
   }
 }

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -668,6 +668,8 @@ open class PagingViewController<T: PagingItem>:
             reloadItems(around: pagingItem)
             selectCollectionViewItem(for: pagingItem, animated: animated)
           }
+        case .reset:
+          collectionViewLayout.invalidateLayout()
         default:
           break
         }
@@ -754,14 +756,16 @@ open class PagingViewController<T: PagingItem>:
       hasItemsAfter: hasItemAfter(pagingItem: sortedItems.last))
     collectionViewLayout.visibleItems = visibleItems
 
-    stateMachine.fire(.select(pagingItem: pagingItem, direction: .none, animated: false))
+    stateMachine.fire(.reset(pagingItem: pagingItem))
     collectionView.reloadData()
+    
+    pageViewController.removeAllViewControllers()
     selectViewController(pagingItem, direction: .none, animated: false)
 
     // Reloading the data triggers the didFinishScrollingFrom delegate
     // to be called which in turn means the wrong item will be selected.
     // For now, we just fix this by selecting the correct item manually.
-    stateMachine.fire(.select(pagingItem: pagingItem, direction: .none, animated: false))
+    stateMachine.fire(.reset(pagingItem: pagingItem))
   }
   
   private func removeAll() {

--- a/Parchment/Enums/PagingEvent.swift
+++ b/Parchment/Enums/PagingEvent.swift
@@ -9,6 +9,7 @@ enum PagingEvent<T: PagingItem> where T: Equatable {
   case cancelScrolling
   case reload(contentOffset: CGPoint)
   case removeAll
+  case reset(pagingItem: T)
 }
 
 extension PagingEvent {


### PR DESCRIPTION
Reloading data without changing the view controllers was not working
due to the way EMPageViewController selects view controllers. Fixed by
removing all view controllers before selecting the new one. This will
just remove the view controller from the view hierarchy, so if you
have store all the view controllers in a property it will just use the
same as before you reloaded.