### PR TITLE
Fix issue with invalidating collection view layout

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -140,6 +140,11 @@ open class PagingCollectionViewLayout<T: PagingItem>:
     invalidationState = .nothing
   }
   
+  open override func invalidateLayout() {
+    super.invalidateLayout()
+    invalidationState = .everything
+  }
+  
   override open func invalidateLayout(with context: UICollectionViewLayoutInvalidationContext) {
     super.invalidateLayout(with: context)
     invalidationState = invalidationState + InvalidationState(context)


### PR DESCRIPTION
Set the internal invalidationState to .everything when calling
invalidateLayout to make sure that all the layout attributes are
invalidated in the prepare call.