### PR TITLE
Fix issue with width delegate not being called

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -777,6 +777,8 @@ open class PagingViewController<T: PagingItem>:
     
     pageViewController.removeAllViewControllers()
     selectViewController(pagingItem, direction: .none, animated: false)
+    
+    configureSizeCache(for: pagingItem)
 
     // Reloading the data triggers the didFinishScrollingFrom delegate
     // to be called which in turn means the wrong item will be selected.


### PR DESCRIPTION
When setting the delegate while the data source is empty, the
widthForPagingItem delegate method would not be called after calling
reload data with the updated data source. Fixed by updating the
internal size cache when reloadData is called.