### PR TITLE
Include vertical insets for indicator view

### DIFF
--- a/Parchment/Classes/PagingIndicatorLayoutAttributes.swift
+++ b/Parchment/Classes/PagingIndicatorLayoutAttributes.swift
@@ -22,10 +22,10 @@ open class PagingIndicatorLayoutAttributes: UICollectionViewLayoutAttributes {
   }
   
   func configure(_ options: PagingOptions) {
-    if case let .visible(height, index, _, _) = options.indicatorOptions {
+    if case let .visible(height, index, _, insets) = options.indicatorOptions {
       backgroundColor = options.indicatorColor
       frame.size.height = height
-      frame.origin.y = options.menuHeight - height
+      frame.origin.y = options.menuHeight - height - insets.bottom + insets.top
       zIndex = index
     }
   }


### PR DESCRIPTION
Account for the top and bottom insets when setting the frame for the
indicator view. This allows you to offset the indicator view from the
bottom of the menu.