### PR TITLE
Remove generics from PagingViewController

### DIFF
--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -5,7 +5,6 @@ import Parchment
 // hold our date. We need to make sure it conforms to Hashable and
 // Comparable, as that is required by PagingViewController. We also
 // cache the formatted date strings for performance.
-
 struct CalendarItem: PagingItem, Hashable, Comparable {
   let date: Date
   let dateText: String
@@ -34,11 +33,9 @@ class ViewController: UIViewController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    
-    // Create an instance of PagingViewController where CalendarItem
-    // is set as the generic type.
-    let pagingViewController = PagingViewController<CalendarItem>()
-	pagingViewController.menuItemSource = .class(type: CalendarPagingCell.self)
+
+    let pagingViewController = PagingViewController()
+    pagingViewController.menuItemSource = .class(type: CalendarPagingCell.self)
     pagingViewController.menuItemSize = .fixed(width: 48, height: 58)
     pagingViewController.textColor = UIColor(red: 95/255, green: 102/255, blue: 108/255, alpha: 1)
     pagingViewController.selectedTextColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
@@ -66,22 +63,21 @@ class ViewController: UIViewController {
 // pagingItemAfterPagingItem: is called, we either subtract or append
 // the time interval equal to one day. This means our paging view
 // controller will show one menu item for each day.
-
 extension ViewController: PagingViewControllerInfiniteDataSource {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForPagingItem pagingItem: T) -> UIViewController {
+  func pagingViewController(_: PagingViewController, itemAfter pagingItem: PagingItem) -> PagingItem? {
+    let calendarItem = pagingItem as! CalendarItem
+    return CalendarItem(date: calendarItem.date.addingTimeInterval(86400))
+  }
+  
+  func pagingViewController(_: PagingViewController, itemBefore pagingItem: PagingItem) -> PagingItem? {
+    let calendarItem = pagingItem as! CalendarItem
+    return CalendarItem(date: calendarItem.date.addingTimeInterval(-86400))
+  }
+  
+  func pagingViewController(_: PagingViewController, viewControllerFor pagingItem: PagingItem) -> UIViewController {
     let calendarItem = pagingItem as! CalendarItem
     return CalendarViewController(date: calendarItem.date)
-  }
-  
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemBeforePagingItem pagingItem: T) -> T? {
-    let calendarItem = pagingItem as! CalendarItem
-    return CalendarItem(date: calendarItem.date.addingTimeInterval(-86400)) as? T
-  }
-  
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemAfterPagingItem pagingItem: T) -> T? {
-    let calendarItem = pagingItem as! CalendarItem
-    return CalendarItem(date: calendarItem.date.addingTimeInterval(86400)) as? T
   }
   
 }

--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -16,15 +16,7 @@ struct CalendarItem: PagingItem, Hashable, Comparable {
     self.weekdayText = DateFormatters.weekdayFormatter.string(from: date)
   }
   
-  var hashValue: Int {
-    return date.hashValue
-  }
-  
-  static func ==(lhs: CalendarItem, rhs: CalendarItem) -> Bool {
-    return lhs.date == rhs.date
-  }
-  
-  static func <(lhs: CalendarItem, rhs: CalendarItem) -> Bool {
+  static func < (lhs: CalendarItem, rhs: CalendarItem) -> Bool {
     return lhs.date < rhs.date
   }
 }

--- a/DelegateExample/ViewController.swift
+++ b/DelegateExample/ViewController.swift
@@ -26,7 +26,7 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    let pagingViewController = PagingViewController<PagingIndexItem>()
+    let pagingViewController = PagingViewController()
     pagingViewController.dataSource = self
     pagingViewController.delegate = self
     
@@ -42,15 +42,15 @@ class ViewController: UIViewController {
 
 extension ViewController: PagingViewControllerDataSource {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemForIndex index: Int) -> T {
-    return PagingIndexItem(index: index, title: cities[index]) as! T
+  func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+    return PagingTitleItem(title: cities[index], index: index)
   }
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForIndex index: Int) -> UIViewController {
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
     return CityViewController(title: cities[index])
   }
   
-  func numberOfViewControllers<T>(in: PagingViewController<T>) -> Int {
+  func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
     return cities.count
   }
   
@@ -64,18 +64,18 @@ extension ViewController: PagingViewControllerDelegate {
   // can access the title string by casting the paging item to a
   // PagingTitleItem, which is the PagingItem type used by
   // FixedPagingViewController.
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, widthForPagingItem pagingItem: T, isSelected: Bool) -> CGFloat? {
-    guard let item = pagingItem as? PagingIndexItem else { return 0 }
-
+  func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat? {
+    guard let item = pagingItem as? PagingTitleItem else { return 0 }
+    
     let insets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
     let size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: pagingViewController.menuItemSize.height)
     let attributes = [NSAttributedString.Key.font: pagingViewController.font]
     
     let rect = item.title.boundingRect(with: size,
-      options: .usesLineFragmentOrigin,
-      attributes: attributes,
-      context: nil)
-
+                                       options: .usesLineFragmentOrigin,
+                                       attributes: attributes,
+                                       context: nil)
+    
     let width = ceil(rect.width) + insets.left + insets.right
     
     if isSelected {

--- a/HeaderExample/ViewController.swift
+++ b/HeaderExample/ViewController.swift
@@ -52,8 +52,7 @@ class CustomPagingView: PagingView {
 
 // Create a custom paging view controller and override the view with
 // our own custom subclass.
-class CustomPagingViewController: PagingViewController<PagingIndexItem> {
-  
+class CustomPagingViewController: PagingViewController {
   override func loadView() {
     view = CustomPagingView(
       options: options,
@@ -103,7 +102,7 @@ class ViewController: UIViewController {
 
 extension ViewController: PagingViewControllerDataSource {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForIndex index: Int) -> UIViewController {
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
     let viewController = TableViewController()
     
     // Inset the table view with the height of the menu height.
@@ -116,11 +115,11 @@ extension ViewController: PagingViewControllerDataSource {
     return viewController
   }
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemForIndex index: Int) -> T {
-    return PagingIndexItem(index: index, title: "View \(index)") as! T
+  func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+    return PagingTitleItem(title: "View \(index)", index: index)
   }
   
-  func numberOfViewControllers<T>(in: PagingViewController<T>) -> Int{
+  func numberOfViewControllers(in: PagingViewController) -> Int{
     return 3
   }
   
@@ -128,7 +127,7 @@ extension ViewController: PagingViewControllerDataSource {
 
 extension ViewController: PagingViewControllerDelegate {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, didScrollToItem pagingItem: T, startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {
+  func pagingViewController(_ pagingViewController: PagingViewController, didScrollToItem pagingItem: PagingItem, startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {
     guard let startingViewController = startingViewController as? TableViewController else { return }
     guard let destinationViewController = destinationViewController as? TableViewController else { return }
     
@@ -140,7 +139,7 @@ extension ViewController: PagingViewControllerDelegate {
     }
   }
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, willScrollToItem pagingItem: T, startingViewController: UIViewController, destinationViewController: UIViewController) {
+  func pagingViewController(_: PagingViewController, willScrollToItem pagingItem: PagingItem, startingViewController: UIViewController, destinationViewController: UIViewController) {
     guard let destinationViewController = destinationViewController as? TableViewController else { return }
 
     // Update the content offset based on the height of the header view.

--- a/IconsExample/ViewController.swift
+++ b/IconsExample/ViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Parchment
 
-struct IconItem: PagingItem, Equatable, Comparable {
+struct IconItem: PagingItem, Hashable, Comparable {
   
   let icon: String
   let index: Int
@@ -13,19 +13,8 @@ struct IconItem: PagingItem, Equatable, Comparable {
     self.image = UIImage(named: icon)
   }
   
-  var identifier: Int {
-    return icon.hashValue
-  }
-  
   static func <(lhs: IconItem, rhs: IconItem) -> Bool {
     return lhs.index < rhs.index
-  }
-  
-  static func ==(lhs: IconItem, rhs: IconItem) -> Bool {
-    return (
-      lhs.index == rhs.index &&
-      lhs.icon == rhs.icon
-    )
   }
 }
 

--- a/IconsExample/ViewController.swift
+++ b/IconsExample/ViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Parchment
 
-struct IconItem: PagingItem, Hashable, Comparable {
+struct IconItem: PagingItem, Equatable, Comparable {
   
   let icon: String
   let index: Int
@@ -13,7 +13,7 @@ struct IconItem: PagingItem, Hashable, Comparable {
     self.image = UIImage(named: icon)
   }
   
-  var hashValue: Int {
+  var identifier: Int {
     return icon.hashValue
   }
   
@@ -59,8 +59,8 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    let pagingViewController = PagingViewController<IconItem>()
-	pagingViewController.menuItemSource = .class(type: IconPagingCell.self)
+    let pagingViewController = PagingViewController()
+	  pagingViewController.menuItemSource = .class(type: IconPagingCell.self)
     pagingViewController.menuItemSize = .fixed(width: 60, height: 60)
     pagingViewController.textColor = UIColor(red: 0.51, green: 0.54, blue: 0.56, alpha: 1)
     pagingViewController.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
@@ -80,15 +80,15 @@ class ViewController: UIViewController {
 
 extension ViewController: PagingViewControllerDataSource {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForIndex index: Int) -> UIViewController {
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
     return IconViewController(title: icons[index].capitalized)
   }
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemForIndex index: Int) -> T {
-    return IconItem(icon: icons[index], index: index) as! T
+  func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+    return IconItem(icon: icons[index], index: index)
   }
   
-  func numberOfViewControllers<T>(in: PagingViewController<T>) -> Int {
+  func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
     return icons.count
   }
   

--- a/LargeTitlesExample/ViewController.swift
+++ b/LargeTitlesExample/ViewController.swift
@@ -34,7 +34,7 @@ class CustomPagingView: PagingView {
 
 // Create a custom paging view controller and override the view with
 // our own custom subclass.
-class CustomPagingViewController: PagingViewController<PagingIndexItem> {
+class CustomPagingViewController: PagingViewController {
     override func loadView() {
         view = CustomPagingView(
             options: options,
@@ -132,7 +132,7 @@ class ViewController: UIViewController {
 
 extension ViewController: PagingViewControllerDataSource {
     
-    func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForIndex index: Int) -> UIViewController {
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
         let viewController = TableViewController(style: .plain)
         
         // Inset the table view with the height of the menu height.
@@ -142,11 +142,11 @@ extension ViewController: PagingViewControllerDataSource {
         return viewController
     }
     
-    func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemForIndex index: Int) -> T {
-        return PagingIndexItem(index: index, title: "View \(index)") as! T
+  func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+        return PagingTitleItem(title: "View \(index)", index: index)
     }
     
-    func numberOfViewControllers<T>(in pagingViewController: PagingViewController<T>) -> Int {
+    func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
         return 3
     }
     
@@ -154,14 +154,14 @@ extension ViewController: PagingViewControllerDataSource {
 
 extension ViewController: PagingViewControllerDelegate {
     
-    func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, willScrollToItem pagingItem: T, startingViewController: UIViewController, destinationViewController: UIViewController) {
+    func pagingViewController(_: PagingViewController, willScrollToItem pagingItem: PagingItem, startingViewController: UIViewController, destinationViewController: UIViewController) {
         guard let startingViewController = startingViewController as? TableViewController else { return }
         // Remove the UITableViewDelegate delegate when starting to
         // scroll to another page.
         startingViewController.tableView.delegate = nil
     }
 
-    func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, didScrollToItem pagingItem: T, startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {
+    func pagingViewController(_: PagingViewController, didScrollToItem pagingItem: PagingItem, startingViewController: UIViewController?, destinationViewController: UIViewController, transitionSuccessful: Bool) {
         guard let destinationViewController = destinationViewController as? TableViewController else { return }
         guard let startingViewController = startingViewController as? TableViewController else { return }
 

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -125,8 +125,9 @@
 		959C9F541FF14AF6005F0ED2 /* Parchment.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; };
 		959C9F551FF14AF6005F0ED2 /* Parchment.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3EA04A4B1C53BFE40054E5E0 /* Parchment.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		959C9F5A1FF14B4F005F0ED2 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 959C9F591FF14B4F005F0ED2 /* Main.storyboard */; };
-		95A0AF001FF707910043B90A /* IndexedPagingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A0AEFF1FF707910043B90A /* IndexedPagingItem.swift */; };
+		95A0AF001FF707910043B90A /* PagingTitleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A0AEFF1FF707910043B90A /* PagingTitleItem.swift */; };
 		95A52A151FF81F70002A2ED4 /* PagingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A52A141FF81F70002A2ED4 /* PagingLayout.swift */; };
+		95A84B0D20ED46920031520F /* AnyPagingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A84B0C20ED46920031520F /* AnyPagingItem.swift */; };
 		95B301001E59E43800B95D02 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B300FF1E59E43800B95D02 /* AppDelegate.swift */; };
 		95B301021E59E43800B95D02 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B301011E59E43800B95D02 /* ViewController.swift */; };
 		95B301051E59E43800B95D02 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95B301031E59E43800B95D02 /* Main.storyboard */; };
@@ -485,8 +486,9 @@
 		9597F2B61E394F63003FD289 /* UIColor+interpolation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+interpolation.swift"; sourceTree = "<group>"; };
 		959C9F591FF14B4F005F0ED2 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		959C9F5B1FF14BB8005F0ED2 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
-		95A0AEFF1FF707910043B90A /* IndexedPagingItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IndexedPagingItem.swift; sourceTree = "<group>"; };
+		95A0AEFF1FF707910043B90A /* PagingTitleItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingTitleItem.swift; sourceTree = "<group>"; };
 		95A52A141FF81F70002A2ED4 /* PagingLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingLayout.swift; sourceTree = "<group>"; };
+		95A84B0C20ED46920031520F /* AnyPagingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyPagingItem.swift; sourceTree = "<group>"; };
 		95B300FD1E59E43800B95D02 /* StoryboardExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StoryboardExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95B300FF1E59E43800B95D02 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95B301011E59E43800B95D02 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -677,7 +679,8 @@
 		3E4090A01C88BCF000800E22 /* Structs */ = {
 			isa = PBXGroup;
 			children = (
-				95A0AEFF1FF707910043B90A /* IndexedPagingItem.swift */,
+				95A84B0C20ED46920031520F /* AnyPagingItem.swift */,
+				95A0AEFF1FF707910043B90A /* PagingTitleItem.swift */,
 				3E49C72D1C8F5CCE006269DD /* PagingCellViewModel.swift */,
 				9548425C1F42486B0072038C /* PagingDiff.swift */,
 				95FE3AF81FFEDBCE00E6F2AD /* PagingDistance.swift */,
@@ -1484,9 +1487,10 @@
 				3E40909D1C88BCC900800E22 /* PagingState.swift in Sources */,
 				954842591F42438E0072038C /* PagingInvalidationContext.swift in Sources */,
 				9597F2951E3903F4003FD289 /* UIColor+interpolation.swift in Sources */,
-				95A0AF001FF707910043B90A /* IndexedPagingItem.swift in Sources */,
+				95A0AF001FF707910043B90A /* PagingTitleItem.swift in Sources */,
 				3E49C72A1C8F5C13006269DD /* PagingViewController.swift in Sources */,
 				3E4090B21C88BDD100800E22 /* PagingStateMachine.swift in Sources */,
+				95A84B0D20ED46920031520F /* AnyPagingItem.swift in Sources */,
 				95E4BA701FF15E84008871A3 /* PagingViewControllerDataSource.swift in Sources */,
 				957F14091E35583500E562F8 /* PagingCellLayoutAttributes.swift in Sources */,
 				3E2AAD281CA831AB0044AAA5 /* UIView+constraints.swift in Sources */,

--- a/Parchment/Classes/FixedPagingViewController.swift
+++ b/Parchment/Classes/FixedPagingViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 /// up-front, which in some cases might be to expensive. If that is
 /// the case, take a look at `PagingViewController` on how to create
 /// your own implementation that matches your needs.
-open class FixedPagingViewController: PagingViewController<PagingIndexItem> {
+open class FixedPagingViewController: PagingViewController {
   
   /// An array of the content view controllers. If you need to call
   /// `select(pagingItem:)` you can use the index of these view
@@ -34,15 +34,16 @@ open class FixedPagingViewController: PagingViewController<PagingIndexItem> {
 
 extension FixedPagingViewController: PagingViewControllerDataSource {
   
-  public func numberOfViewControllers<T>(in: PagingViewController<T>) -> Int {
+  public func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
     return viewControllers.count
   }
   
-  public func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemForIndex index: Int) -> T {
-    return PagingIndexItem(index: index, title: viewControllers[index].title ?? "") as! T
+  public func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+    let title = viewControllers[index].title ?? ""
+    return PagingTitleItem(title: title, index: index)
   }
   
-  public func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForIndex index: Int) -> UIViewController {
+  public func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
     return viewControllers[index]
   }
   

--- a/Parchment/Classes/IndexedPagingDataSource.swift
+++ b/Parchment/Classes/IndexedPagingDataSource.swift
@@ -1,15 +1,12 @@
 import Foundation
 
-class IndexedPagingDataSource<T: PagingItem>:
-  PagingViewControllerInfiniteDataSource where T: Hashable & Comparable {
+class IndexedPagingDataSource: PagingViewControllerInfiniteDataSource {
   
-  var items: [T] = []
+  var items: [PagingItem] = []
   var viewControllerForIndex: ((Int) -> UIViewController?)?
   
-  func pagingViewController<U>(
-    _ pagingViewController: PagingViewController<U>,
-    viewControllerForPagingItem item: U) -> UIViewController {
-    guard let index = items.index(of: item as! T) else {
+  func pagingViewController(_: PagingViewController, viewControllerFor pagingItem: PagingItem) -> UIViewController {
+    guard let index = items.index(where: { $0.isEqual(to: pagingItem) }) else {
       fatalError("pagingViewController:viewControllerForPagingItem: PagingItem does not exist")
     }
     guard let viewController = viewControllerForIndex?(index) else {
@@ -19,22 +16,18 @@ class IndexedPagingDataSource<T: PagingItem>:
     return viewController
   }
   
-  func pagingViewController<U>(
-    _ pagingViewController: PagingViewController<U>,
-    pagingItemBeforePagingItem item: U) -> U? {
-    guard let index = items.index(of: item as! T) else { return nil }
+  func pagingViewController(_: PagingViewController, itemBefore pagingItem: PagingItem) -> PagingItem? {
+    guard let index = items.index(where: { $0.isEqual(to: pagingItem) }) else { return nil }
     if index > 0 {
-      return items[index - 1] as? U
+      return items[index - 1]
     }
     return nil
   }
   
-  func pagingViewController<U>(
-    _ pagingViewController: PagingViewController<U>,
-    pagingItemAfterPagingItem item: U) -> U? {
-    guard let index = items.index(of: item as! T) else { return nil }
+  func pagingViewController(_: PagingViewController, itemAfter pagingItem: PagingItem) -> PagingItem? {
+    guard let index = items.index(where: { $0.isEqual(to: pagingItem) }) else { return nil }
     if index < items.count - 1 {
-      return items[index + 1] as? U
+      return items[index + 1]
     }
     return nil
   }

--- a/Parchment/Classes/PagingSizeCache.swift
+++ b/Parchment/Classes/PagingSizeCache.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-class PagingSizeCache<T: PagingItem>  where T: Hashable & Comparable {
+class PagingSizeCache {
   
   var implementsWidthDelegate: Bool = false
-  var widthForPagingItem: ((T, Bool) -> CGFloat?)?
+  var widthForPagingItem: ((PagingItem, Bool) -> CGFloat?)?
   
   private let options: PagingOptions
-  private var widthCache: [T: CGFloat] = [:]
-  private var selectedWidthCache: [T: CGFloat] = [:]
+  private var widthCache: [Int: CGFloat] = [:]
+  private var selectedWidthCache: [Int: CGFloat] = [:]
   
   init(options: PagingOptions) {
     self.options = options
@@ -40,22 +40,22 @@ class PagingSizeCache<T: PagingItem>  where T: Hashable & Comparable {
     self.selectedWidthCache = [:]
   }
   
-  func itemWidth(for pagingItem: T) -> CGFloat {
-    if let width = widthCache[pagingItem] {
+  func itemWidth(for pagingItem: PagingItem) -> CGFloat {
+    if let width = widthCache[pagingItem.identifier] {
       return width
     } else {
       let width = widthForPagingItem?(pagingItem, false)
-      widthCache[pagingItem] = width
+      widthCache[pagingItem.identifier] = width
       return width ?? options.estimatedItemWidth
     }
   }
   
-  func itemWidthSelected(for pagingItem: T) -> CGFloat {
-    if let width = selectedWidthCache[pagingItem] {
+  func itemWidthSelected(for pagingItem: PagingItem) -> CGFloat {
+    if let width = selectedWidthCache[pagingItem.identifier] {
       return width
     } else {
       let width = widthForPagingItem?(pagingItem, true)
-      selectedWidthCache[pagingItem] = width
+      selectedWidthCache[pagingItem.identifier] = width
       return width ?? options.estimatedItemWidth
     }
   }

--- a/Parchment/Enums/PagingEvent.swift
+++ b/Parchment/Enums/PagingEvent.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-enum PagingEvent<T: PagingItem> where T: Equatable {
+enum PagingEvent {
   case scroll(progress: CGFloat)
-  case initial(pagingItem: T)
-  case select(pagingItem: T, direction: PagingDirection, animated: Bool)
+  case initial(pagingItem: PagingItem)
+  case select(pagingItem: PagingItem, direction: PagingDirection, animated: Bool)
   case finishScrolling
   case transitionSize
   case cancelScrolling
   case reload(contentOffset: CGPoint)
   case removeAll
-  case reset(pagingItem: T)
+  case reset(pagingItem: PagingItem)
 }
 
 extension PagingEvent {

--- a/Parchment/Enums/PagingState.swift
+++ b/Parchment/Enums/PagingState.swift
@@ -3,12 +3,12 @@ import Foundation
 /// The current state of the menu items. Indicates whether an item
 /// is currently selected or is scrolling to another item. Can be
 /// used to get the distance and progress of any ongoing transition.
-public enum PagingState<T: PagingItem>: Equatable where T: Equatable {
+public enum PagingState: Equatable {
   case empty
-  case selected(pagingItem: T)
+  case selected(pagingItem: PagingItem)
   case scrolling(
-    pagingItem: T,
-    upcomingPagingItem: T?,
+    pagingItem: PagingItem,
+    upcomingPagingItem: PagingItem?,
     progress: CGFloat,
     initialContentOffset: CGPoint,
     distance: CGFloat)
@@ -16,7 +16,7 @@ public enum PagingState<T: PagingItem>: Equatable where T: Equatable {
 
 public extension PagingState {
   
-  public var currentPagingItem: T? {
+  public var currentPagingItem: PagingItem? {
     switch self {
     case .empty:
       return nil
@@ -27,7 +27,7 @@ public extension PagingState {
     }
   }
   
-  public var upcomingPagingItem: T? {
+  public var upcomingPagingItem: PagingItem? {
     switch self {
     case .empty:
       return nil
@@ -56,7 +56,7 @@ public extension PagingState {
     }
   }
   
-  public var visuallySelectedPagingItem: T? {
+  public var visuallySelectedPagingItem: PagingItem? {
     if abs(progress) > 0.5 {
       return upcomingPagingItem ?? currentPagingItem
     } else {
@@ -66,23 +66,23 @@ public extension PagingState {
   
 }
 
-public func ==<T>(lhs: PagingState<T>, rhs: PagingState<T>) -> Bool {
+public func ==(lhs: PagingState, rhs: PagingState) -> Bool {
   switch (lhs, rhs) {
   case
     (let .scrolling(lhsCurrent, lhsUpcoming, lhsProgress, lhsOffset, lhsDistance),
      let .scrolling(rhsCurrent, rhsUpcoming, rhsProgress, rhsOffset, rhsDistance)):
-    if lhsCurrent == rhsCurrent &&
+    if lhsCurrent.isEqual(to: rhsCurrent) &&
       lhsProgress == rhsProgress &&
       lhsOffset == rhsOffset &&
       lhsDistance == rhsDistance {
-      if let lhsUpcoming = lhsUpcoming, let rhsUpcoming = rhsUpcoming, lhsUpcoming == rhsUpcoming {
+      if let lhsUpcoming = lhsUpcoming, let rhsUpcoming = rhsUpcoming, lhsUpcoming.isEqual(to: rhsUpcoming) {
         return true
       } else if lhsUpcoming == nil && rhsUpcoming == nil {
         return true
       }
     }
     return false
-  case (let .selected(a), let .selected(b)) where a == b:
+  case (let .selected(a), let .selected(b)) where a.isEqual(to: b):
     return true
   case (.empty, .empty):
     return true

--- a/Parchment/Protocols/PagingItem.swift
+++ b/Parchment/Protocols/PagingItem.swift
@@ -3,12 +3,29 @@ import Foundation
 /// The `PagingItem` protocol is used to generate menu items for all
 /// the view controllers, without having to actually allocate them
 /// before they are needed. You can store whatever you want in here
-/// that makes sense for what you're displaying. The only requirement
-/// is that it conforms to `Hashable` and `Comparable`.
-public protocol PagingItem {}
+/// that makes sense for what you're displaying.
+public protocol PagingItem {
+  var identifier: Int { get }
+  func isEqual(to item: PagingItem) -> Bool
+  func isBefore(item: PagingItem) -> Bool
+}
 
-/// The `PagingTitleItem` protocol is used the `PagingTitleCell` to
-/// store a title that is going to be display in the menu items.
-public protocol PagingTitleItem: PagingItem {
-  var title: String { get }
+extension PagingItem where Self: Equatable {
+  public func isEqual(to item: PagingItem) -> Bool {
+    guard let item = item as? Self else { return false }
+    return self == item
+  }
+}
+
+extension PagingItem where Self: Comparable {
+  public func isBefore(item: PagingItem) -> Bool {
+    guard let item = item as? Self else { return false }
+    return self < item
+  }
+}
+
+extension PagingItem where Self: Hashable {
+  public var identifier: Int {
+    return self.hashValue
+  }
 }

--- a/Parchment/Protocols/PagingViewControllerDataSource.swift
+++ b/Parchment/Protocols/PagingViewControllerDataSource.swift
@@ -15,8 +15,7 @@ public protocol PagingViewControllerDataSource: class {
   /// - Parameter pagingViewController: The `PagingViewController`
   /// instance
   /// - Returns: The number of view controllers
-  func numberOfViewControllers<T>(
-    in pagingViewController: PagingViewController<T>) -> Int
+  func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int
   
   /// Return the view controller accociated with a given index. This
   /// method is only called for the currently selected `PagingItem`,
@@ -26,16 +25,12 @@ public protocol PagingViewControllerDataSource: class {
   /// instance
   /// - Parameter index: The index of a given `PagingItem`
   /// - Returns: The view controller for the given index
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    viewControllerForIndex index: Int) -> UIViewController
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController
   
   /// Return the `PagingItem` instance for a given index
   ///
   /// - Parameter pagingViewController: The `PagingViewController`
   /// instance
   /// - Returns: The `PagingItem` instance
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    pagingItemForIndex index: Int) -> T
+  func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem
 }

--- a/Parchment/Protocols/PagingViewControllerDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerDelegate.swift
@@ -14,10 +14,10 @@ public protocol PagingViewControllerDelegate: class {
   /// - Parameter destinationViewController: The view controller for
   /// the upcoming paging item
   /// - Parameter progress: The progress of the scroll transition
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    isScrollingFromItem currentPagingItem: T,
-    toItem upcomingPagingItem: T?,
+  func pagingViewController(
+    _: PagingViewController,
+    isScrollingFromItem currentPagingItem: PagingItem,
+    toItem upcomingPagingItem: PagingItem?,
     startingViewController: UIViewController,
     destinationViewController: UIViewController?,
     progress: CGFloat)
@@ -29,9 +29,9 @@ public protocol PagingViewControllerDelegate: class {
   /// current paging item
   /// - Parameter destinationViewController: The view controller for
   /// the upcoming paging item
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    willScrollToItem pagingItem: T,
+  func pagingViewController(
+    _: PagingViewController,
+    willScrollToItem pagingItem: PagingItem,
     startingViewController: UIViewController,
     destinationViewController: UIViewController)
   
@@ -44,9 +44,9 @@ public protocol PagingViewControllerDelegate: class {
   /// the upcoming paging item
   /// - Parameter transitionSuccessful: Boolean that indicates whether
   /// the transition to the paging item was successful or not
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    didScrollToItem pagingItem: T,
+  func pagingViewController(
+    _ pagingViewController: PagingViewController,
+    didScrollToItem pagingItem: PagingItem,
     startingViewController: UIViewController?,
     destinationViewController: UIViewController,
     transitionSuccessful: Bool)
@@ -61,44 +61,44 @@ public protocol PagingViewControllerDelegate: class {
   /// - Parameter isSelected: A boolean that indicates whether the
   /// given `PagingItem` is selected
   /// - Returns: The width for the `PagingItem` or nil
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    widthForPagingItem pagingItem: T,
+  func pagingViewController(
+    _: PagingViewController,
+    widthForPagingItem pagingItem: PagingItem,
     isSelected: Bool) -> CGFloat?
 }
 
 public extension PagingViewControllerDelegate {
 
-  public func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    isScrollingFromItem currentPagingItem: T,
-    toItem upcomingPagingItem: T?,
+  public func pagingViewController(
+    _: PagingViewController,
+    isScrollingFromItem currentPagingItem: PagingItem,
+    toItem upcomingPagingItem: PagingItem?,
     startingViewController: UIViewController,
     destinationViewController: UIViewController?,
     progress: CGFloat) {
     return
   }
   
-  public func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    willScrollToItem pagingItem: T,
+  public func pagingViewController(
+    _ pagingViewController: PagingViewController,
+    willScrollToItem pagingItem: PagingItem,
     startingViewController: UIViewController,
     destinationViewController: UIViewController) {
     return
   }
   
-  public func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    didScrollToItem pagingItem: T,
+  public func pagingViewController(
+    _ pagingViewController: PagingViewController,
+    didScrollToItem pagingItem: PagingItem,
     startingViewController: UIViewController?,
     destinationViewController: UIViewController,
     transitionSuccessful: Bool) {
     return
   }
   
-  public func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    widthForPagingItem pagingItem: T,
+  public func pagingViewController(
+    _ pagingViewController: PagingViewController,
+    widthForPagingItem pagingItem: PagingItem,
     isSelected: Bool) -> CGFloat? {
     return nil
   }

--- a/Parchment/Protocols/PagingViewControllerInfiniteDataSource.swift
+++ b/Parchment/Protocols/PagingViewControllerInfiniteDataSource.swift
@@ -17,9 +17,7 @@ public protocol PagingViewControllerInfiniteDataSource: class {
   /// instance
   /// - Parameter viewControllerForPagingItem: A `PagingItem` instance
   /// - Returns: The view controller for the `PagingItem` instance
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    viewControllerForPagingItem: T) -> UIViewController
+  func pagingViewController(_: PagingViewController, viewControllerFor pagingItem: PagingItem) -> UIViewController
 
   /// The `PagingItem` that comes before a given `PagingItem`
   ///
@@ -29,9 +27,7 @@ public protocol PagingViewControllerInfiniteDataSource: class {
   /// - Returns: The `PagingItem` that appears before the given
   /// `PagingItem`, or `nil` to indicate that no more progress can be
   /// made in that direction.
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    pagingItemBeforePagingItem: T) -> T?
+  func pagingViewController(_: PagingViewController, itemBefore pagingItem: PagingItem) -> PagingItem?
   
   /// The `PagingItem` that comes after a given `PagingItem`
   ///
@@ -41,7 +37,5 @@ public protocol PagingViewControllerInfiniteDataSource: class {
   /// - Returns: The `PagingItem` that appears after the given
   /// `PagingItem`, or `nil` to indicate that no more progress can be
   /// made in that direction.
-  func pagingViewController<T>(
-    _ pagingViewController: PagingViewController<T>,
-    pagingItemAfterPagingItem: T) -> T?
+  func pagingViewController(_ : PagingViewController, itemAfter pagingItem: PagingItem) -> PagingItem?
 }

--- a/Parchment/Structs/AnyPagingItem.swift
+++ b/Parchment/Structs/AnyPagingItem.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct AnyPagingItem: PagingItem, Hashable, Comparable {
+  let base: PagingItem
+  
+  init(base: PagingItem) {
+    self.base = base
+  }
+  
+  var hashValue: Int {
+    return base.identifier
+  }
+  
+  static func < (lhs: AnyPagingItem, rhs: AnyPagingItem) -> Bool {
+    return lhs.base.isBefore(item: rhs.base)
+  }
+  
+  static func == (lhs: AnyPagingItem, rhs: AnyPagingItem) -> Bool {
+    return lhs.base.isEqual(to: rhs.base)
+  }
+}

--- a/Parchment/Structs/PagingDiff.swift
+++ b/Parchment/Structs/PagingDiff.swift
@@ -1,30 +1,30 @@
 import Foundation
 
-struct PagingDiff<T: PagingItem> where T: Hashable & Comparable {
+struct PagingDiff {
   
-  private let from: PagingItems<T>
-  private let to: PagingItems<T>
-  private var fromCache: [Int: T]
-  private var toCache: [Int: T]
-  private var lastMatchingItem: T?
+  private let from: PagingItems
+  private let to: PagingItems
+  private var fromCache: [Int: PagingItem]
+  private var toCache: [Int: PagingItem]
+  private var lastMatchingItem: PagingItem?
   
-  init(from: PagingItems<T>, to: PagingItems<T>) {
+  init(from: PagingItems, to: PagingItems) {
     self.from = from
     self.to = to
     self.fromCache = [:]
     self.toCache = [:]
     
     for item in from.items {
-      fromCache[item.hashValue] = item
+      fromCache[item.identifier] = item
     }
     
     for item in to.items {
-      toCache[item.hashValue] = item
+      toCache[item.identifier] = item
     }
     
     for toItem in to.items {
       for fromItem in from.items {
-        if toItem == fromItem {
+        if toItem.isEqual(to: fromItem) {
           lastMatchingItem = toItem
           break
         }
@@ -68,10 +68,10 @@ struct PagingDiff<T: PagingItem> where T: Hashable & Comparable {
     return items
   }
   
-  private func diff(visibleItems: PagingItems<T>, cache: [Int: T]) -> [IndexPath] {
+  private func diff(visibleItems: PagingItems, cache: [Int: PagingItem]) -> [IndexPath] {
     #if swift(>=4.1)
       return visibleItems.items.compactMap { item in
-        if cache[item.hashValue] == nil {
+        if cache[item.identifier] == nil {
           return visibleItems.indexPath(for: item)
         }
         return nil

--- a/Parchment/Structs/PagingDistance.swift
+++ b/Parchment/Structs/PagingDistance.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
+struct PagingDistance {
   
   let view: UIScrollView
-  let currentPagingItem: T
-  let upcomingPagingItem: T
-  let visibleItems: PagingItems<T>
-  let sizeCache: PagingSizeCache<T>
+  let currentPagingItem: PagingItem
+  let upcomingPagingItem: PagingItem
+  let visibleItems: PagingItems
+  let sizeCache: PagingSizeCache
   let selectedScrollPosition: PagingSelectedScrollPosition
   let layoutAttributes: [IndexPath: PagingCellLayoutAttributes]
   
@@ -81,7 +81,7 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
     if sizeCache.implementsWidthDelegate {
       if let currentIndexPath = visibleItems.indexPath(for: currentPagingItem),
         let from = layoutAttributes[currentIndexPath] {
-        if upcomingPagingItem > currentPagingItem {
+        if currentPagingItem.isBefore(item: upcomingPagingItem) {
           let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
           let fromDiff = from.bounds.width - fromWidth
           distance -= fromDiff
@@ -104,7 +104,7 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
     if sizeCache.implementsWidthDelegate {
       if let currentIndexPath = visibleItems.indexPath(for: currentPagingItem),
         let from = layoutAttributes[currentIndexPath] {
-        if upcomingPagingItem < currentPagingItem {
+        if upcomingPagingItem.isBefore(item: currentPagingItem) {
           let toDiff = toWidth - to.bounds.width
           distance += toDiff
         } else {
@@ -140,7 +140,7 @@ struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
       if sizeCache.implementsWidthDelegate {
         let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
         
-        if upcomingPagingItem < currentPagingItem {
+        if upcomingPagingItem.isBefore(item: currentPagingItem) {
           distance = -(to.bounds.width + (from.center.x - (to.center.x + (to.bounds.width / 2))) - (toWidth / 2)) - distanceToCenter
         } else {
           let toDiff = (toWidth - to.bounds.width) / 2

--- a/Parchment/Structs/PagingItems.swift
+++ b/Parchment/Structs/PagingItems.swift
@@ -3,20 +3,24 @@ import Foundation
 /// A data structure used to hold an array of `PagingItem`'s, with
 /// methods for getting the index path for a given `PagingItem` and
 /// vice versa.
-public struct PagingItems<T: PagingItem> where T: Hashable & Comparable {
+public struct PagingItems {
   
   /// A sorted array of the currently visible `PagingItem`'s.
-  public let items: [T]
+  public let items: [PagingItem]
   
   let hasItemsBefore: Bool
   let hasItemsAfter: Bool
-  let itemsCache: Set<T>
+  private var cachedItems: [Int: PagingItem]
   
-  init(items: [T], hasItemsBefore: Bool = false, hasItemsAfter: Bool = false) {
+  init(items: [PagingItem], hasItemsBefore: Bool = false, hasItemsAfter: Bool = false) {
     self.items = items
     self.hasItemsBefore = hasItemsBefore
     self.hasItemsAfter = hasItemsAfter
-    self.itemsCache = Set(items)
+    self.cachedItems = [:]
+    
+    for item in items {
+      cachedItems[item.identifier] = item
+    }
   }
   
   /// The `IndexPath` for a given `PagingItem`. Returns nil if the
@@ -24,8 +28,8 @@ public struct PagingItems<T: PagingItem> where T: Hashable & Comparable {
   ///
   /// - Parameter pagingItem: A `PagingItem` instance
   /// - Returns: The `IndexPath` for the given `PagingItem`
-  public func indexPath(for pagingItem: T) -> IndexPath? {
-    guard let index = items.index(of: pagingItem) else { return nil }
+  public func indexPath(for pagingItem: PagingItem) -> IndexPath? {
+    guard let index = items.index(where: { $0.isEqual(to: pagingItem) }) else { return nil }
     return IndexPath(item: index, section: 0)
   }
   
@@ -35,7 +39,7 @@ public struct PagingItems<T: PagingItem> where T: Hashable & Comparable {
   ///
   /// - Parameter indexPath: An `IndexPath` that is currently visible
   /// - Returns: The `PagingItem` for the given `IndexPath`
-  public func pagingItem(for indexPath: IndexPath) -> T {
+  public func pagingItem(for indexPath: IndexPath) -> PagingItem {
     return items[indexPath.item]
   }
   
@@ -45,14 +49,26 @@ public struct PagingItems<T: PagingItem> where T: Hashable & Comparable {
   /// - Parameter from: The current `PagingItem`
   /// - Parameter to: The `PagingItem` being scrolled towards
   /// - Returns: The `PagingDirection` for a given `PagingItem`
-  public func direction(from: T, to: T) -> PagingDirection {
-    if itemsCache.contains(from) == false {
+  public func direction(from: PagingItem, to: PagingItem) -> PagingDirection {
+    if contains(from) == false {
       return .none
-    } else if to > from {
+    } else if from.isBefore(item: to) {
       return .forward
-    } else if to < from {
+    } else if to.isBefore(item: from) {
       return .reverse
     }
     return .none
+  }
+  
+  func contains(_ pagingItem: PagingItem) -> Bool {
+    return cachedItems[pagingItem.identifier] != nil ? true : false
+  }
+  
+  func union(_ newItems: [PagingItem]) -> [PagingItem] {
+    let old = Set(items.map { AnyPagingItem(base: $0) })
+    let new = Set(newItems.map { AnyPagingItem(base: $0) })
+    return Array(old.union(new))
+      .map({ $0.base })
+      .sorted(by: { $0.isBefore(item: $1) })
   }
 }

--- a/Parchment/Structs/PagingTitleItem.swift
+++ b/Parchment/Structs/PagingTitleItem.swift
@@ -3,17 +3,13 @@ import UIKit
 /// An implementation of the `PagingItem` protocol that stores the
 /// index and title of a given item. The index property is needed to
 /// make the `PagingItem` comparable.
-public struct PagingTitleItem: PagingItem, Equatable, Comparable {
+public struct PagingTitleItem: PagingItem, Hashable, Comparable {
   
   /// The index of the `PagingItem` instance
   public let index: Int
   
   /// The title used in the menu cells.
   public let title: String
-  
-  public var identifier: Int {
-    return index
-  }
   
   /// Creates an instance of `PagingTitleItem`
   ///
@@ -22,10 +18,6 @@ public struct PagingTitleItem: PagingItem, Equatable, Comparable {
   public init(title: String, index: Int) {
     self.title = title
     self.index = index
-  }
-  
-  public static func ==(lhs: PagingTitleItem, rhs: PagingTitleItem) -> Bool {
-    return lhs.index == rhs.index && lhs.title == rhs.title
   }
   
   public static func <(lhs: PagingTitleItem, rhs: PagingTitleItem) -> Bool {

--- a/Parchment/Structs/PagingTitleItem.swift
+++ b/Parchment/Structs/PagingTitleItem.swift
@@ -2,9 +2,8 @@ import UIKit
 
 /// An implementation of the `PagingItem` protocol that stores the
 /// index and title of a given item. The index property is needed to
-/// make the `PagingItem` comparable. Used by default when using
-/// `IndexedPagingViewController`.
-public struct PagingIndexItem: PagingTitleItem, Equatable, Hashable, Comparable {
+/// make the `PagingItem` comparable.
+public struct PagingTitleItem: PagingItem, Equatable, Comparable {
   
   /// The index of the `PagingItem` instance
   public let index: Int
@@ -12,25 +11,24 @@ public struct PagingIndexItem: PagingTitleItem, Equatable, Hashable, Comparable 
   /// The title used in the menu cells.
   public let title: String
   
-  public var hashValue: Int {
+  public var identifier: Int {
     return index
   }
   
-  /// Creates an instance of `PagingIndexItem`
+  /// Creates an instance of `PagingTitleItem`
   ///
   /// Parameter index: The index of the `PagingItem`.
   /// Parameter title: The title used in the menu cells.
-  public init(index: Int, title: String) {
+  public init(title: String, index: Int) {
     self.title = title
     self.index = index
   }
   
-  public static func ==(lhs: PagingIndexItem, rhs: PagingIndexItem) -> Bool {
+  public static func ==(lhs: PagingTitleItem, rhs: PagingTitleItem) -> Bool {
     return lhs.index == rhs.index && lhs.title == rhs.title
   }
   
-  public static func <(lhs: PagingIndexItem, rhs: PagingIndexItem) -> Bool {
+  public static func <(lhs: PagingTitleItem, rhs: PagingTitleItem) -> Bool {
     return lhs.index < rhs.index
   }
 }
-

--- a/ParchmentTests/Item.swift
+++ b/ParchmentTests/Item.swift
@@ -1,10 +1,10 @@
 import Foundation
 @testable import Parchment
 
-struct Item: PagingItem, Hashable, Comparable {
+struct Item: PagingItem, Equatable, Comparable {
   let index: Int
   
-  var hashValue: Int {
+  var identifier: Int {
     return index
   }
 }

--- a/ParchmentTests/PagingDataStructureSpec.swift
+++ b/ParchmentTests/PagingDataStructureSpec.swift
@@ -9,7 +9,7 @@ class PagingDataSpec: QuickSpec {
     
     describe("PagingData") {
       
-      var visibleItems: PagingItems<Item>!
+      var visibleItems: PagingItems!
       
       beforeEach {
         visibleItems = PagingItems(items: [
@@ -36,7 +36,7 @@ class PagingDataSpec: QuickSpec {
       describe("pagingItemForIndexPath:") {
         it("returns the paging item for a given index path") {
           let indexPath = IndexPath(item: 0, section: 0)
-          let pagingItem = visibleItems.pagingItem(for: indexPath)
+          let pagingItem = visibleItems.pagingItem(for: indexPath) as! Item
           expect(pagingItem).to(equal(Item(index: 0)))
         }
       }

--- a/ParchmentTests/PagingDiffSpec.swift
+++ b/ParchmentTests/PagingDiffSpec.swift
@@ -10,8 +10,8 @@ class PagingDiffSpec: QuickSpec {
     describe("added") {
       
       it("ignores added items after center") {
-        let from = PagingItems<Item>(items: [Item(index: 0)])
-        let to = PagingItems<Item>(items: [Item(index: 0), Item(index: 1)])
+        let from = PagingItems(items: [Item(index: 0)])
+        let to = PagingItems(items: [Item(index: 0), Item(index: 1)])
         let diff = PagingDiff(from: from, to: to)
         
         expect(diff.added()).to(beEmpty())
@@ -19,8 +19,8 @@ class PagingDiffSpec: QuickSpec {
       }
       
       it("detects added items before center") {
-        let from = PagingItems<Item>(items: [Item(index: 1)])
-        let to = PagingItems<Item>(items: [Item(index: 0), Item(index: 1)])
+        let from = PagingItems(items: [Item(index: 1)])
+        let to = PagingItems(items: [Item(index: 0), Item(index: 1)])
         let diff = PagingDiff(from: from, to: to)
         let added = diff.added()
         let removed = diff.removed()
@@ -33,7 +33,7 @@ class PagingDiffSpec: QuickSpec {
       // TODO: Reduce these tests to a minimal test case and update
       // the descriptions.
       it("passes scenario #1") {
-        let from = PagingItems<Item>(items: [
+        let from = PagingItems(items: [
           Item(index: 16),
           Item(index: 17),
           Item(index: 18),
@@ -51,7 +51,7 @@ class PagingDiffSpec: QuickSpec {
           Item(index: 30)
         ])
         
-        let to = PagingItems<Item>(items: [
+        let to = PagingItems(items: [
           Item(index: 9),
           Item(index: 10),
           Item(index: 11),
@@ -85,7 +85,7 @@ class PagingDiffSpec: QuickSpec {
       }
       
       it("passes scenario #2") {
-        let from = PagingItems<Item>(items: [
+        let from = PagingItems(items: [
           Item(index: 0),
           Item(index: 1),
           Item(index: 2),
@@ -97,7 +97,7 @@ class PagingDiffSpec: QuickSpec {
           Item(index: 8)
         ])
         
-        let to = PagingItems<Item>(items: [
+        let to = PagingItems(items: [
           Item(index: 4),
           Item(index: 5),
           Item(index: 6),
@@ -121,14 +121,14 @@ class PagingDiffSpec: QuickSpec {
       
       it("passes scenario #3") {
         
-        let from = PagingItems<Item>(items: [
+        let from = PagingItems(items: [
           Item(index: 1),
           Item(index: 2),
           Item(index: 10),
           Item(index: 11)
         ])
         
-        let to = PagingItems<Item>(items: [
+        let to = PagingItems(items: [
           Item(index: 2),
           Item(index: 3)
         ])
@@ -147,8 +147,8 @@ class PagingDiffSpec: QuickSpec {
     describe("removed") {
       
       it("ignores removed items after center") {
-        let from = PagingItems<Item>(items: [Item(index: 0), Item(index: 1)])
-        let to = PagingItems<Item>(items: [Item(index: 0)])
+        let from = PagingItems(items: [Item(index: 0), Item(index: 1)])
+        let to = PagingItems(items: [Item(index: 0)])
         let diff = PagingDiff(from: from, to: to);
         
         expect(diff.removed()).to(beEmpty())
@@ -156,8 +156,8 @@ class PagingDiffSpec: QuickSpec {
       }
       
       it("detects removed items before center") {
-        let from = PagingItems<Item>(items: [Item(index: 0), Item(index: 1)])
-        let to = PagingItems<Item>(items: [Item(index: 1)])
+        let from = PagingItems(items: [Item(index: 0), Item(index: 1)])
+        let to = PagingItems(items: [Item(index: 1)])
         let diff = PagingDiff(from: from, to: to);
         let removed = diff.removed()
         let added = diff.added()

--- a/ParchmentTests/PagingStateMachineSpec.swift
+++ b/ParchmentTests/PagingStateMachineSpec.swift
@@ -3,8 +3,8 @@ import Quick
 import Nimble
 @testable import Parchment
 
-private func beScrolling() -> Predicate<PagingState<Item>> {
-  return Predicate.define("be .Scrolling)") { expression, message in
+private func beScrolling() -> Predicate<PagingState> {
+  return Predicate.define("be .scrolling)") { expression, message in
     if let actual = try expression.evaluate(), case .scrolling = actual {
       return PredicateResult(bool: true, message: message)
     }
@@ -12,8 +12,8 @@ private func beScrolling() -> Predicate<PagingState<Item>> {
   }
 }
 
-private func beSelected() -> Predicate<PagingState<Item>> {
-  return Predicate.define("be .Selected)") { expression, message in
+private func beSelected() -> Predicate<PagingState> {
+  return Predicate.define("be .selected)") { expression, message in
     if let actual = try expression.evaluate(), case .selected = actual {
       return PredicateResult(bool: true, message: message)
     }
@@ -27,17 +27,19 @@ class PagingStateMachineSpec: QuickSpec {
     
     describe("PagingStateMachine") {
       
-      var stateMachine: PagingStateMachine<Item>!
+      var stateMachine: PagingStateMachine!
       
       beforeEach {
         let state: PagingState = .selected(pagingItem: Item(index: 0))
         stateMachine = PagingStateMachine(initialState: state)
         
         stateMachine.pagingItemAfterItem = { item in
+          guard let item = item as? Item else { return nil }
           return Item(index: item.index + 1)
         }
         
         stateMachine.pagingItemBeforeItem = { item in
+          guard let item = item as? Item else { return nil }
           return Item(index: item.index - 1)
         }
         
@@ -76,7 +78,7 @@ class PagingStateMachineSpec: QuickSpec {
           describe("has an upcoming paging item") {
             it("sets the selected item to equal the upcoming paging item") {
               stateMachine.fire(.finishScrolling)
-              expect(stateMachine.state.currentPagingItem).to(equal(Item(index: 1)))
+              expect(stateMachine.state.currentPagingItem as! Item?).to(equal(Item(index: 1)))
             }
           }
           
@@ -94,7 +96,7 @@ class PagingStateMachineSpec: QuickSpec {
             
             it("sets the selected item to equal the current paging item") {
               stateMachine.fire(.finishScrolling)
-              expect(stateMachine.state.currentPagingItem).to(equal(Item(index: 0)))
+              expect(stateMachine.state.currentPagingItem as! Item?).to(equal(Item(index: 0)))
             }
           }
           
@@ -212,7 +214,7 @@ class PagingStateMachineSpec: QuickSpec {
                 pagingItem: Item(index: 1),
                 direction: .none,
                 animated: false))
-              expect(stateMachine.state.currentPagingItem).to(equal(Item(index: 0)))
+              expect(stateMachine.state.currentPagingItem as! Item?).to(equal(Item(index: 0)))
             }
             
             it("sets the upcoming paging item to the selected paging item") {
@@ -220,7 +222,7 @@ class PagingStateMachineSpec: QuickSpec {
                 pagingItem: Item(index: 1),
                 direction: .none,
                 animated: false))
-              expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: 1)))
+              expect(stateMachine.state.upcomingPagingItem as! Item?).to(equal(Item(index: 1)))
             }
             
             describe("has a select block") {
@@ -231,7 +233,7 @@ class PagingStateMachineSpec: QuickSpec {
                 var animated: Bool?
                 
                 stateMachine.onPagingItemSelect = {
-                  selectedPagingItem = $0
+                  selectedPagingItem = $0 as? Item
                   direction = $1
                   animated = $2
                 }
@@ -264,7 +266,7 @@ class PagingStateMachineSpec: QuickSpec {
           describe("has a select block") {
             
             it("does not call the select block") {
-              var selectedPagingItem: Item?
+              var selectedPagingItem: PagingItem?
               
               stateMachine.onPagingItemSelect = { pagingItem, _, _ in
                 selectedPagingItem = pagingItem
@@ -288,7 +290,7 @@ class PagingStateMachineSpec: QuickSpec {
         
         it("uses the state's current paging item") {
           stateMachine.fire(.scroll(progress: 0))
-          expect(stateMachine.state.currentPagingItem).to(equal(Item(index: 0)))
+          expect(stateMachine.state.currentPagingItem as! Item?).to(equal(Item(index: 0)))
         }
         
         it("sets the new progress") {
@@ -351,7 +353,7 @@ class PagingStateMachineSpec: QuickSpec {
                 distance: 0)
               stateMachine = PagingStateMachine(initialState: initialState)
               stateMachine.fire(.scroll(progress: 0.1))
-              expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: 1)))
+              expect(stateMachine.state.upcomingPagingItem as! Item?).to(equal(Item(index: 1)))
             }
             
           }
@@ -368,12 +370,12 @@ class PagingStateMachineSpec: QuickSpec {
           
           it("uses the leading paging item if the progress is negative") {
             stateMachine.fire(.scroll(progress: -0.1))
-            expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: -1)))
+            expect(stateMachine.state.upcomingPagingItem as! Item?).to(equal(Item(index: -1)))
           }
           
           it("uses the trailing paging item if the progress is positive") {
             stateMachine.fire(.scroll(progress: 0.1))
-            expect(stateMachine.state.upcomingPagingItem).to(equal(Item(index: 1)))
+            expect(stateMachine.state.upcomingPagingItem as! Item?).to(equal(Item(index: 1)))
           }
           
         }

--- a/ParchmentTests/PagingStateSpec.swift
+++ b/ParchmentTests/PagingStateSpec.swift
@@ -18,7 +18,7 @@ class PagingStateSpec: QuickSpec {
             progress: 0,
             initialContentOffset: .zero,
             distance: 0)
-          expect(state.currentPagingItem).to(equal(Item(index: 0)))
+          expect(state.currentPagingItem as! Item?).to(equal(Item(index: 0)))
         }
         
         it("returns the correct progress") {
@@ -40,7 +40,7 @@ class PagingStateSpec: QuickSpec {
               progress: 0,
               initialContentOffset: .zero,
               distance: 0)
-            expect(state.upcomingPagingItem).to(equal(Item(index: 1)))
+            expect(state.upcomingPagingItem as! Item?).to(equal(Item(index: 1)))
           }
           
           describe("visuallySelectedPagingItem") {
@@ -53,7 +53,7 @@ class PagingStateSpec: QuickSpec {
                   progress: 0.6,
                   initialContentOffset: .zero,
                   distance: 0)
-                expect(state.visuallySelectedPagingItem).to(equal(Item(index: 1)))
+                expect(state.visuallySelectedPagingItem as! Item?).to(equal(Item(index: 1)))
               }
             }
             
@@ -65,7 +65,7 @@ class PagingStateSpec: QuickSpec {
                   progress: 0.3,
                   initialContentOffset: .zero,
                   distance: 0)
-                expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
+                expect(state.visuallySelectedPagingItem as! Item?).to(equal(Item(index: 0)))
               }
             }
             
@@ -95,7 +95,7 @@ class PagingStateSpec: QuickSpec {
                   progress: 0.6,
                   initialContentOffset: .zero,
                   distance: 0)
-                expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
+                expect(state.visuallySelectedPagingItem as! Item?).to(equal(Item(index: 0)))
               }
             }
             
@@ -107,7 +107,7 @@ class PagingStateSpec: QuickSpec {
                   progress: 0.3,
                   initialContentOffset: .zero,
                   distance: 0)
-                expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
+                expect(state.visuallySelectedPagingItem as! Item?).to(equal(Item(index: 0)))
               }
             }
             
@@ -121,7 +121,7 @@ class PagingStateSpec: QuickSpec {
         let state: PagingState = .selected(pagingItem: Item(index: 0))
         
         it("returns the current paging item") {
-          expect(state.currentPagingItem).to(equal(Item(index: 0)))
+          expect(state.currentPagingItem as! Item?).to(equal(Item(index: 0)))
         }
         
         it("returns nil for the upcoming paging item") {
@@ -133,7 +133,7 @@ class PagingStateSpec: QuickSpec {
         }
         
         it("returns the current paging item as the visually selected item") {
-          expect(state.visuallySelectedPagingItem).to(equal(Item(index: 0)))
+          expect(state.visuallySelectedPagingItem as! Item?).to(equal(Item(index: 0)))
         }
         
       }

--- a/ScrollExample/ViewController.swift
+++ b/ScrollExample/ViewController.swift
@@ -33,8 +33,7 @@ class CustomPagingView: PagingView {
 
 // Create a custom paging view controller and override the view with
 // our own custom subclass.
-class CustomPagingViewController: PagingViewController<PagingIndexItem> {
-  
+class CustomPagingViewController: PagingViewController {
   override func loadView() {
     view = CustomPagingView(
       options: options,
@@ -72,7 +71,7 @@ class ViewController: UIViewController {
 
 extension ViewController: PagingViewControllerDataSource {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForIndex index: Int) -> UIViewController {
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
     let viewController = TableViewController()
     
     // Inset the table view with the height of the menu height.
@@ -87,11 +86,11 @@ extension ViewController: PagingViewControllerDataSource {
     return viewController
   }
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemForIndex index: Int) -> T {
-    return PagingIndexItem(index: index, title: "View \(index)") as! T
+  func pagingViewController(_ pagingViewController: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+    return PagingTitleItem(title: "View \(index)", index: index)
   }
   
-  func numberOfViewControllers<T>(in: PagingViewController<T>) -> Int{
+  func numberOfViewControllers(in: PagingViewController) -> Int{
     return 3
   }
   
@@ -113,7 +112,7 @@ extension ViewController: PagingViewControllerDelegate {
   
   // We want to transition the menu offset smoothly to it correct
   // position when we are swiping between pages.
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, isScrollingFromItem currentPagingItem: T, toItem upcomingPagingItem: T?, startingViewController: UIViewController, destinationViewController: UIViewController?, progress: CGFloat) {
+  func pagingViewController(_: PagingViewController, isScrollingFromItem currentPagingItem: PagingItem, toItem upcomingPagingItem: PagingItem?, startingViewController: UIViewController, destinationViewController: UIViewController?, progress: CGFloat) {
     guard let destinationViewController = destinationViewController as? TableViewController else { return }
     guard let startingViewController = startingViewController as? TableViewController else { return }
     guard let menuView = pagingViewController.view as? CustomPagingView else { return }
@@ -126,5 +125,5 @@ extension ViewController: PagingViewControllerDelegate {
     
     menuView.menuTopConstraint?.constant = -offset
   }
+  
 }
-

--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -12,15 +12,7 @@ struct ImageItem: PagingItem, Hashable, Comparable {
   let headerImage: UIImage
   let images: [UIImage]
   
-  var hashValue: Int {
-    return index.hashValue &+ title.hashValue
-  }
-  
-  static func ==(lhs: ImageItem, rhs: ImageItem) -> Bool {
-    return lhs.index == rhs.index && lhs.title == rhs.title
-  }
-  
-  static func <(lhs: ImageItem, rhs: ImageItem) -> Bool {
+  static func < (lhs: ImageItem, rhs: ImageItem) -> Bool {
     return lhs.index < rhs.index
   }
 }

--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -55,8 +55,7 @@ class CustomPagingView: PagingView {
 
 // Create a custom paging view controller and override the view with
 // our own custom subclass.
-class CustomPagingViewController: PagingViewController<ImageItem> {
-  
+class CustomPagingViewController: PagingViewController {
   override func loadView() {
     view = CustomPagingView(
       options: options,
@@ -78,7 +77,8 @@ class ViewController: UIViewController {
         UIImage(named: "green-2")!,
         UIImage(named: "green-3")!,
         UIImage(named: "green-4")!,
-        ]),
+        ]
+    ),
     ImageItem(
       index: 1,
       title: "Food",
@@ -88,7 +88,8 @@ class ViewController: UIViewController {
         UIImage(named: "food-2")!,
         UIImage(named: "food-3")!,
         UIImage(named: "food-4")!,
-        ]),
+        ]
+    ),
     ImageItem(
       index: 2,
       title: "Succulents",
@@ -98,7 +99,8 @@ class ViewController: UIViewController {
         UIImage(named: "succulents-2")!,
         UIImage(named: "succulents-3")!,
         UIImage(named: "succulents-4")!,
-        ]),
+        ]
+    ),
     ImageItem(
       index: 3,
       title: "City",
@@ -108,7 +110,8 @@ class ViewController: UIViewController {
         UIImage(named: "city-2")!,
         UIImage(named: "city-1")!,
         UIImage(named: "city-4")!,
-        ]),
+        ]
+    ),
     ImageItem(
       index: 4,
       title: "Scenic",
@@ -118,7 +121,8 @@ class ViewController: UIViewController {
         UIImage(named: "scenic-2")!,
         UIImage(named: "scenic-3")!,
         UIImage(named: "scenic-4")!,
-        ]),
+        ]
+    ),
     ImageItem(
       index: 5,
       title: "Coffee",
@@ -128,8 +132,9 @@ class ViewController: UIViewController {
         UIImage(named: "coffee-2")!,
         UIImage(named: "coffee-3")!,
         UIImage(named: "coffee-4")!,
-        ]),
-    ]
+        ]
+    )
+  ]
   
   // Create our custom paging view controller.
   private let pagingViewController = CustomPagingViewController()
@@ -213,7 +218,7 @@ class ViewController: UIViewController {
 
 extension ViewController: PagingViewControllerDataSource {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, viewControllerForIndex index: Int) -> UIViewController {
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
     let viewController = ImagesViewController(
       images: items[index].images,
       options: pagingViewController.options
@@ -231,11 +236,11 @@ extension ViewController: PagingViewControllerDataSource {
     return viewController
   }
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, pagingItemForIndex index: Int) -> T {
-    return items[index] as! T
+  func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+    return items[index]
   }
   
-  func numberOfViewControllers<T>(in: PagingViewController<T>) -> Int{
+  func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
     return items.count
   }
   
@@ -254,7 +259,7 @@ extension ViewController: ImagesViewControllerDelegate {
 
 extension ViewController: PagingViewControllerDelegate {
   
-  func pagingViewController<T>(_ pagingViewController: PagingViewController<T>, isScrollingFromItem currentPagingItem: T, toItem upcomingPagingItem: T?, startingViewController: UIViewController, destinationViewController: UIViewController?, progress: CGFloat) {
+  func pagingViewController(_: PagingViewController, isScrollingFromItem currentPagingItem: PagingItem, toItem upcomingPagingItem: PagingItem?, startingViewController: UIViewController, destinationViewController: UIViewController?, progress: CGFloat) {
     guard let destinationViewController = destinationViewController as? ImagesViewController else { return }
     guard let startingViewController = startingViewController as? ImagesViewController else { return }
     


### PR DESCRIPTION
Removing the generic type on PagingViewController will clean up the
API quite a lot. Using generics does not really give us any benefits,
as you need to cast the type in the delegate and data sources anyway.

This commit also renames PagingIndexItem to PagingTitleItem, and
updates the data source protocols to be a bit more Swifty.