### PR TITLE
Fix indicator insets with only one item

### DIFF
--- a/Parchment/Classes/PagingCollectionViewLayout.swift
+++ b/Parchment/Classes/PagingCollectionViewLayout.swift
@@ -436,7 +436,9 @@ open class PagingCollectionViewLayout<T: PagingItem>:
   
   private func indicatorInsetsForIndex(_ index: Int) -> PagingIndicatorMetric.Inset {
     if case let .visible(_, _, _, insets) = options.indicatorOptions {
-      if index == range.lowerBound {
+      if index == 0 && range.upperBound == 1 {
+        return .both(insets.left, insets.right)
+      } else if index == range.lowerBound {
         return .left(insets.left)
       } else if index >= range.upperBound - 1 {
         return .right(insets.right)

--- a/Parchment/Structs/PagingIndicatorMetric.swift
+++ b/Parchment/Structs/PagingIndicatorMetric.swift
@@ -5,6 +5,7 @@ struct PagingIndicatorMetric {
   enum Inset {
     case left(CGFloat)
     case right(CGFloat)
+    case both(CGFloat, CGFloat)
     case none
   }
   
@@ -14,7 +15,7 @@ struct PagingIndicatorMetric {
   
   var x: CGFloat {
     switch insets {
-    case let .left(inset):
+    case let .left(inset), let .both(inset, _):
       return frame.origin.x + max(inset, spacing.left)
     default:
       return frame.origin.x + spacing.left
@@ -27,6 +28,8 @@ struct PagingIndicatorMetric {
       return frame.size.width - max(inset, spacing.left) - spacing.right
     case let .right(inset):
       return frame.size.width - max(inset, spacing.right) - spacing.left
+    case let .both(insetLeft, insetRight):
+      return frame.size.width - max(insetRight, spacing.right) - max(insetLeft, spacing.left)
     case .none:
       return frame.size.width - spacing.left - spacing.right
     }


### PR DESCRIPTION
When showing only a single menu item, the indicator insets was not
applied to both sides.