### PR TITLE
Move customization properties into PagingOptions

### DIFF
--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -27,11 +27,11 @@ class ViewController: UIViewController {
     super.viewDidLoad()
 
     let pagingViewController = PagingViewController()
-    pagingViewController.menuItemSource = .class(type: CalendarPagingCell.self)
-    pagingViewController.menuItemSize = .fixed(width: 48, height: 58)
-    pagingViewController.textColor = UIColor(red: 95/255, green: 102/255, blue: 108/255, alpha: 1)
-    pagingViewController.selectedTextColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
-    pagingViewController.indicatorColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
+    pagingViewController.options.menuItemSource = .class(type: CalendarPagingCell.self)
+    pagingViewController.options.menuItemSize = .fixed(width: 48, height: 58)
+    pagingViewController.options.textColor = UIColor(red: 95/255, green: 102/255, blue: 108/255, alpha: 1)
+    pagingViewController.options.selectedTextColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
+    pagingViewController.options.indicatorColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
     
     // Add the paging view controller as a child view
     // controller and constrain it to all edges

--- a/DelegateExample/ViewController.swift
+++ b/DelegateExample/ViewController.swift
@@ -68,8 +68,8 @@ extension ViewController: PagingViewControllerDelegate {
     guard let item = pagingItem as? PagingTitleItem else { return 0 }
     
     let insets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
-    let size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: pagingViewController.menuItemSize.height)
-    let attributes = [NSAttributedString.Key.font: pagingViewController.font]
+    let size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: pagingViewController.options.menuItemSize.height)
+    let attributes = [NSAttributedString.Key.font: pagingViewController.options.font]
     
     let rect = item.title.boundingRect(with: size,
                                        options: .usesLineFragmentOrigin,

--- a/HeaderExample/ViewController.swift
+++ b/HeaderExample/ViewController.swift
@@ -75,9 +75,9 @@ class ViewController: UIViewController {
     pagingViewController.didMove(toParent: self)
     
     // Customize the menu styling.
-    pagingViewController.selectedTextColor = .black
-    pagingViewController.indicatorColor = .black
-    pagingViewController.indicatorOptions = .visible(
+    pagingViewController.options.selectedTextColor = .black
+    pagingViewController.options.indicatorColor = .black
+    pagingViewController.options.indicatorOptions = .visible(
       height: 1,
       zIndex: Int.max,
       spacing: .zero,

--- a/IconsExample/ViewController.swift
+++ b/IconsExample/ViewController.swift
@@ -49,11 +49,11 @@ class ViewController: UIViewController {
     super.viewDidLoad()
     
     let pagingViewController = PagingViewController()
-	  pagingViewController.menuItemSource = .class(type: IconPagingCell.self)
-    pagingViewController.menuItemSize = .fixed(width: 60, height: 60)
-    pagingViewController.textColor = UIColor(red: 0.51, green: 0.54, blue: 0.56, alpha: 1)
-    pagingViewController.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
-    pagingViewController.indicatorColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
+	  pagingViewController.options.menuItemSource = .class(type: IconPagingCell.self)
+    pagingViewController.options.menuItemSize = .fixed(width: 60, height: 60)
+    pagingViewController.options.textColor = UIColor(red: 0.51, green: 0.54, blue: 0.56, alpha: 1)
+    pagingViewController.options.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
+    pagingViewController.options.indicatorColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
     pagingViewController.dataSource = self
     pagingViewController.select(pagingItem: IconItem(icon: icons[0], index: 0))
     

--- a/LargeTitlesExample/ViewController.swift
+++ b/LargeTitlesExample/ViewController.swift
@@ -59,12 +59,12 @@ class ViewController: UIViewController {
         guard let navigationController = navigationController else { return }
         
         // Customize the menu to match the navigation bar color
-        pagingViewController.menuBackgroundColor = UIColor(red: 85/255, green: 66/255, blue: 232/255, alpha: 1)
-        pagingViewController.menuItemSize = .fixed(width: 150, height: 30)
-        pagingViewController.textColor = UIColor.white.withAlphaComponent(0.7)
-        pagingViewController.selectedTextColor = UIColor.white
-        pagingViewController.borderOptions = .hidden
-        pagingViewController.indicatorColor = UIColor(red: 10/255, green: 0, blue: 105/255, alpha: 1)
+        pagingViewController.options.menuBackgroundColor = UIColor(red: 85/255, green: 66/255, blue: 232/255, alpha: 1)
+        pagingViewController.options.menuItemSize = .fixed(width: 150, height: 30)
+        pagingViewController.options.textColor = UIColor.white.withAlphaComponent(0.7)
+        pagingViewController.options.selectedTextColor = UIColor.white
+        pagingViewController.options.borderOptions = .hidden
+        pagingViewController.options.indicatorColor = UIColor(red: 10/255, green: 0, blue: 105/255, alpha: 1)
         
         // Add the "hidden" scroll view to the root of the UIViewController.
         view.addSubview(hiddenScrollView)
@@ -99,7 +99,7 @@ class ViewController: UIViewController {
         navigationController.view.addSubview(pagingViewController.collectionView)
         pagingViewController.collectionView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            pagingViewController.collectionView.heightAnchor.constraint(equalToConstant: pagingViewController.menuItemSize.height),
+            pagingViewController.collectionView.heightAnchor.constraint(equalToConstant: pagingViewController.options.menuItemSize.height),
             pagingViewController.collectionView.leadingAnchor.constraint(equalTo: navigationController.view.leadingAnchor),
             pagingViewController.collectionView.trailingAnchor.constraint(equalTo: navigationController.view.trailingAnchor),
             pagingViewController.collectionView.topAnchor.constraint(equalTo: navigationController.navigationBar.bottomAnchor),
@@ -136,7 +136,7 @@ extension ViewController: PagingViewControllerDataSource {
         let viewController = TableViewController(style: .plain)
         
         // Inset the table view with the height of the menu height.
-        let insets = UIEdgeInsets(top: pagingViewController.menuItemSize.height, left: 0, bottom: 0, right: 0)
+        let insets = UIEdgeInsets(top: pagingViewController.options.menuItemSize.height, left: 0, bottom: 0, right: 0)
         viewController.tableView.scrollIndicatorInsets = insets
         viewController.tableView.contentInset = insets
         return viewController

--- a/NavigationBarExample/ViewController.swift
+++ b/NavigationBarExample/ViewController.swift
@@ -17,7 +17,7 @@ class CustomPagingView: PagingView {
 
 // Create a custom paging view controller and override the view with
 // our own custom subclass.
-class CustomPagingViewController: FixedPagingViewController {
+class CustomPagingViewController: PagingViewController {
   override func loadView() {
     view = CustomPagingView(
       options: options,
@@ -39,11 +39,11 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    pagingViewController.borderOptions = .hidden
-    pagingViewController.menuBackgroundColor = .clear
-    pagingViewController.indicatorColor = UIColor(white: 0, alpha: 0.4)
-    pagingViewController.textColor = UIColor(white: 1, alpha: 0.6)
-    pagingViewController.selectedTextColor = .white
+    pagingViewController.options.borderOptions = .hidden
+    pagingViewController.options.menuBackgroundColor = .clear
+    pagingViewController.options.indicatorColor = UIColor(white: 0, alpha: 0.4)
+    pagingViewController.options.textColor = UIColor(white: 1, alpha: 0.6)
+    pagingViewController.options.selectedTextColor = .white
     
     // Make sure you add the PagingViewController as a child view
     // controller and contrain it to the edges of the view.
@@ -62,7 +62,7 @@ class ViewController: UIViewController {
     super.viewDidLayoutSubviews()
     guard let navigationBar = navigationController?.navigationBar else { return }
     navigationItem.titleView?.frame = CGRect(origin: .zero, size: navigationBar.bounds.size)
-    pagingViewController.menuItemSize = .fixed(width: 100, height: navigationBar.bounds.height)
+    pagingViewController.options.menuItemSize = .fixed(width: 100, height: navigationBar.bounds.height)
   }
   
 }

--- a/Parchment/Classes/PagingOptions.swift
+++ b/Parchment/Classes/PagingOptions.swift
@@ -1,29 +1,96 @@
 import UIKit
 
-public class PagingOptions {
+public struct PagingOptions {
+  
+  /// The size for each of the menu items. _Default:
+  /// .sizeToFit(minWidth: 150, height: 40)_
   public var menuItemSize: PagingMenuItemSize
+  
+  /// The class type for the menu item. Override this if you want
+  /// your own custom menu items. _Default: PagingTitleCell.self_
   public var menuItemSource: PagingMenuItemSource
+  
+  /// Determine the spacing between the menu items. _Default: 0_
   public var menuItemSpacing: CGFloat
+  
+  /// Determine the insets at around all the menu items. _Default:
+  /// UIEdgeInsets.zero_
   public var menuInsets: UIEdgeInsets
+  
+  /// Determine whether the menu items should be centered when all the
+  /// items can fit within the bounds of the view. _Default: .left_
   public var menuHorizontalAlignment: PagingMenuHorizontalAlignment
+  
+  /// Determine the transition behaviour of menu items while scrolling
+  /// the content. _Default: .scrollAlongside_
   public var menuTransition: PagingMenuTransition
+  
+  /// Determine how users can interact with the menu items.
+  /// _Default: .scrolling_
   public var menuInteraction: PagingMenuInteraction
-  public var contentInteraction: PagingContentInteraction
+  
+  /// The class type for collection view layout. Override this if you
+  /// want to use your own subclass of the layout. Setting this
+  /// property will initialize the new layout type and update the
+  /// collection view.
+  /// _Default: PagingCollectionViewLayout.self_
+  public var menuLayoutClass: PagingCollectionViewLayout.Type
+  
+  /// Determine how the selected menu item should be aligned when it
+  /// is selected. Effectivly the same as the
+  /// `UICollectionViewScrollPosition`. _Default: .preferCentered_
   public var selectedScrollPosition: PagingSelectedScrollPosition
+  
+  /// Add an indicator view to the selected menu item. The indicator
+  /// width will be equal to the selected menu items width. Insets
+  /// only apply horizontally. _Default: .visible_
   public var indicatorOptions: PagingIndicatorOptions
+  
+  /// The class type for the indicator view. Override this if you want
+  /// your use your own subclass of PagingIndicatorView. _Default:
+  /// PagingIndicatorView.self_
   public var indicatorClass: PagingIndicatorView.Type
-  public var borderOptions: PagingBorderOptions
-  public var borderClass: PagingBorderView.Type
-  public var includeSafeAreaInsets: Bool
-  public var font: UIFont
-  public var selectedFont: UIFont
-  public var textColor: UIColor
-  public var selectedTextColor: UIColor
-  public var backgroundColor: UIColor
-  public var selectedBackgroundColor: UIColor
-  public var menuBackgroundColor: UIColor
-  public var borderColor: UIColor
+  
+  /// Determine the color of the indicator view.
   public var indicatorColor: UIColor
+  
+  /// Add a border at the bottom of the menu items. The border will be
+  /// as wide as all the menu items. Insets only apply horizontally.
+  /// _Default: .visible_
+  public var borderOptions: PagingBorderOptions
+  
+  /// The class type for the border view. Override this if you want
+  /// your use your own subclass of PagingBorderView. _Default:
+  /// PagingBorderView.self_
+  public var borderClass: PagingBorderView.Type
+  
+  /// Determine the color of the border view.
+  public var borderColor: UIColor
+  
+  /// Updates the content inset for the menu items based on the
+  /// .safeAreaInsets property. _Default: true_
+  public var includeSafeAreaInsets: Bool
+  
+  /// The font used for title label on the menu items.
+  public var font: UIFont
+  
+  /// The font used for the currently selected menu item.
+  public var selectedFont: UIFont
+  
+  /// The color of the title label on the menu items.
+  public var textColor: UIColor
+  
+  /// The text color for the currently selected menu item.
+  public var selectedTextColor: UIColor
+  
+  /// The background color for the menu items.
+  public var backgroundColor: UIColor
+  
+  /// The background color for the selected menu item.
+  public var selectedBackgroundColor: UIColor
+  
+  /// The background color for the view behind the menu items.
+  public var menuBackgroundColor: UIColor
   
   #if swift(>=4.2)
   public var scrollPosition: UICollectionView.ScrollPosition {
@@ -74,7 +141,7 @@ public class PagingOptions {
     includeSafeAreaInsets = true
     indicatorClass = PagingIndicatorView.self
     borderClass = PagingBorderView.self
-    contentInteraction = .scrolling
+    menuLayoutClass = PagingCollectionViewLayout.self
     
     indicatorOptions = .visible(
         height: 4,

--- a/Parchment/Classes/PagingSizeCache.swift
+++ b/Parchment/Classes/PagingSizeCache.swift
@@ -2,10 +2,10 @@ import Foundation
 
 class PagingSizeCache {
   
+  var options: PagingOptions
   var implementsWidthDelegate: Bool = false
   var widthForPagingItem: ((PagingItem, Bool) -> CGFloat?)?
   
-  private let options: PagingOptions
   private var widthCache: [Int: CGFloat] = [:]
   private var selectedWidthCache: [Int: CGFloat] = [:]
   

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -19,198 +19,12 @@ open class PagingViewController:
 
   // MARK: Public Properties
   
-  /// The size for each of the menu items. _Default:
-  /// .sizeToFit(minWidth: 150, height: 40)_
-  public var menuItemSize: PagingMenuItemSize {
-    get { return options.menuItemSize }
-    set { options.menuItemSize = newValue }
-  }
-
-  /// The class type for the menu item. Override this if you want
-  /// your own custom menu items. _Default: PagingTitleCell.self_
-  public var menuItemSource: PagingMenuItemSource {
-    get { return options.menuItemSource }
-    set { options.menuItemSource = newValue }
-  }
-
-  /// Determine the spacing between the menu items. _Default: 0_
-  public var menuItemSpacing: CGFloat {
-    get { return options.menuItemSpacing }
-    set { options.menuItemSpacing = newValue }
-  }
-
-  /// Determine the insets at around all the menu items. _Default:
-  /// UIEdgeInsets.zero_
-  public var menuInsets: UIEdgeInsets {
-    get { return options.menuInsets }
-    set { options.menuInsets = newValue }
-  }
-
-  /// Determine whether the menu items should be centered when all the
-  /// items can fit within the bounds of the view. _Default: .left_
-  public var menuHorizontalAlignment: PagingMenuHorizontalAlignment {
-    get { return options.menuHorizontalAlignment }
-    set { options.menuHorizontalAlignment = newValue }
-  }
-
-  /// Determine the transition behaviour of menu items while scrolling
-  /// the content. _Default: .scrollAlongside_
-  public var menuTransition: PagingMenuTransition {
-    get { return options.menuTransition }
-    set { options.menuTransition = newValue }
-  }
-
-  /// Determine how users can interact with the menu items.
-  /// _Default: .scrolling_
-  public var menuInteraction: PagingMenuInteraction {
-    get { return options.menuInteraction }
-    set {
-      options.menuInteraction = newValue
-      pagingController.configureCollectionView()
-    }
-  }
-  
-  /// The class type for collection view layout. Override this if you
-  /// want to use your own subclass of the layout. Setting this
-  /// property will initialize the new layout type and update the
-  /// collection view.
-  /// _Default: PagingCollectionViewLayout.self_
-  public var menuLayoutClass: PagingCollectionViewLayout.Type = PagingCollectionViewLayout.self {
-    didSet {
-      let layout = createLayout(layout: menuLayoutClass.self)
-      self.collectionViewLayout = layout
-      configureCollectionViewLayout()
-      collectionView.setCollectionViewLayout(layout, animated: false)
-    }
-  }
-  
   /// Determine how users can interact with the page view controller.
   /// _Default: .scrolling_
-  public var contentInteraction: PagingContentInteraction {
-    get { return options.contentInteraction }
-    set {
-      options.contentInteraction = newValue
+  public var contentInteraction: PagingContentInteraction = .scrolling {
+    didSet {
       configureContentInteraction()
     }
-  }
-
-  /// Determine how the selected menu item should be aligned when it
-  /// is selected. Effectivly the same as the
-  /// `UICollectionViewScrollPosition`. _Default: .preferCentered_
-  public var selectedScrollPosition: PagingSelectedScrollPosition {
-    get { return options.selectedScrollPosition }
-    set { options.selectedScrollPosition = newValue }
-  }
-
-  /// Add an indicator view to the selected menu item. The indicator
-  /// width will be equal to the selected menu items width. Insets
-  /// only apply horizontally. _Default: .visible_
-  public var indicatorOptions: PagingIndicatorOptions {
-    get { return options.indicatorOptions }
-    set {
-      options.indicatorOptions = newValue
-      collectionViewLayout.invalidateLayout()
-    }
-  }
-
-  /// The class type for the indicator view. Override this if you want
-  /// your use your own subclass of PagingIndicatorView. _Default:
-  /// PagingIndicatorView.self_
-  public var indicatorClass: PagingIndicatorView.Type {
-    get { return options.indicatorClass }
-    set {
-      options.indicatorClass = newValue
-      collectionViewLayout.registerIndicatorClass()
-    }
-  }
-
-  /// Determine the color of the indicator view.
-  public var indicatorColor: UIColor {
-    get { return options.indicatorColor }
-    set {
-      options.indicatorColor = newValue
-      collectionViewLayout.invalidateLayout()
-    }
-  }
-  
-  /// Add a border at the bottom of the menu items. The border will be
-  /// as wide as all the menu items. Insets only apply horizontally.
-  /// _Default: .visible_
-  public var borderOptions: PagingBorderOptions {
-    get { return options.borderOptions }
-    set {
-      options.borderOptions = newValue
-      collectionViewLayout.invalidateLayout()
-    }
-  }
-
-  /// The class type for the border view. Override this if you want
-  /// your use your own subclass of PagingBorderView. _Default:
-  /// PagingBorderView.self_
-  public var borderClass: PagingBorderView.Type {
-    get { return options.borderClass }
-    set {
-      options.borderClass = newValue
-      collectionViewLayout.registerBorderClass()
-    }
-  }
-  
-  /// Determine the color of the border view.
-  public var borderColor: UIColor {
-    get { return options.borderColor }
-    set {
-      options.borderColor = newValue
-      collectionViewLayout.invalidateLayout()
-    }
-  }
-
-  /// Updates the content inset for the menu items based on the
-  /// .safeAreaInsets property. _Default: true_
-  public var includeSafeAreaInsets: Bool {
-    get { return options.includeSafeAreaInsets }
-    set { options.includeSafeAreaInsets = newValue }
-  }
-
-  /// The font used for title label on the menu items.
-  public var font: UIFont {
-    get { return options.font }
-    set { options.font = newValue }
-  }
-
-  /// The font used for the currently selected menu item.
-  public var selectedFont: UIFont {
-    get { return options.selectedFont }
-    set { options.selectedFont = newValue }
-  }
-
-  /// The color of the title label on the menu items.
-  public var textColor: UIColor {
-    get { return options.textColor }
-    set { options.textColor = newValue }
-  }
-
-  /// The text color for the currently selected menu item.
-  public var selectedTextColor: UIColor {
-    get { return options.selectedTextColor }
-    set { options.selectedTextColor = newValue }
-  }
-
-  /// The background color for the menu items.
-  public var backgroundColor: UIColor {
-    get { return options.backgroundColor }
-    set { options.backgroundColor = newValue }
-  }
-  
-  /// The background color for the selected menu item.
-  public var selectedBackgroundColor: UIColor {
-    get { return options.selectedBackgroundColor }
-    set { options.selectedBackgroundColor = newValue }
-  }
-
-  /// The background color for the view behind the menu items.
-  public var menuBackgroundColor: UIColor {
-    get { return options.menuBackgroundColor }
-    set { options.menuBackgroundColor = newValue }
   }
   
   /// The current state of the menu items. Indicates whether an item
@@ -277,10 +91,22 @@ open class PagingViewController:
   public let pageViewController: EMPageViewController
 
   /// An instance that stores all the customization so that it's
-  /// easier to share between other classes. You should use the
-  /// customization properties on PagingViewController, instead of
-  /// setting values on this class directly.
-  public let options: PagingOptions
+  /// easier to share between other classes.
+  public var options: PagingOptions {
+    didSet {
+      if options.menuLayoutClass != oldValue.menuLayoutClass {
+        let layout = createLayout(layout: options.menuLayoutClass.self)
+        collectionViewLayout = layout
+        collectionViewLayout.options = options
+        collectionView.setCollectionViewLayout(layout, animated: false)
+      }
+      else {
+        collectionViewLayout.options = options
+      }
+      
+      pagingController.options = options
+    }
+  }
   
   // MARK: Private Properties
   
@@ -309,12 +135,11 @@ open class PagingViewController:
     self.options = PagingOptions()
     self.pagingController = PagingController(options: options)
     self.pageViewController = EMPageViewController(navigationOrientation: .horizontal)
-    self.collectionViewLayout = createLayout(layout: menuLayoutClass.self)
+    self.collectionViewLayout = createLayout(layout: options.menuLayoutClass.self)
     self.collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
     super.init(nibName: nil, bundle: nil)
     collectionView.delegate = self
     configurePagingController()
-    configureCollectionViewLayout()
   }
   
   public convenience init(viewControllers: [UIViewController]) {
@@ -329,12 +154,11 @@ open class PagingViewController:
     self.options = PagingOptions()
     self.pagingController = PagingController(options: options)
     self.pageViewController = EMPageViewController(navigationOrientation: .horizontal)
-    self.collectionViewLayout = createLayout(layout: menuLayoutClass.self)
+    self.collectionViewLayout = createLayout(layout: options.menuLayoutClass.self)
     self.collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
     super.init(coder: coder)
     collectionView.delegate = self
     configurePagingController()
-    configureCollectionViewLayout()
   }
   
   // MARK: Public Methods
@@ -506,12 +330,6 @@ open class PagingViewController:
     pagingController.delegate = self
   }
   
-  private func configureCollectionViewLayout() {
-    collectionViewLayout.pagingController = pagingController
-    collectionViewLayout.registerIndicatorClass()
-    collectionViewLayout.registerBorderClass()
-  }
-  
   private func itemsForFiniteDataSource() -> [PagingItem] {
     let numberOfItems = dataSource?.numberOfViewControllers(in: self) ?? 0
     var items: [PagingItem] = []
@@ -550,7 +368,7 @@ open class PagingViewController:
   }
   
   private func configureContentInteraction() {
-    switch options.contentInteraction {
+    switch contentInteraction {
     case .scrolling:
       pageViewController.scrollView.isScrollEnabled = true
     case .none:

--- a/Parchment/Enums/PagingMenuItemSource.swift
+++ b/Parchment/Enums/PagingMenuItemSource.swift
@@ -4,3 +4,18 @@ public enum PagingMenuItemSource {
 	case `class`(type: PagingCell.Type)
 	case nib(nib: UINib)
 }
+
+extension PagingMenuItemSource: Equatable {
+  public static func == (lhs: PagingMenuItemSource, rhs: PagingMenuItemSource) -> Bool {
+    switch (lhs, rhs) {
+    case let (.class(lhsType), .class(rhsType)):
+      return lhsType != rhsType
+      
+    case let (.nib(lhsNib), .nib(rhsNib)):
+      return lhsNib === rhsNib
+      
+    default:
+      return false
+    }
+  }
+}

--- a/Parchment/Protocols/CollectionView.swift
+++ b/Parchment/Protocols/CollectionView.swift
@@ -1,6 +1,9 @@
 import UIKit
 
 protocol CollectionViewLayout: class {
+  var state: PagingState { get set }
+  var visibleItems: PagingItems { get set }
+  var sizeCache: PagingSizeCache? { get set }
   var contentInsets: UIEdgeInsets { get }
   var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] { get }
   func prepare()

--- a/ParchmentTests/Mocks/MockCollectionViewLayout.swift
+++ b/ParchmentTests/Mocks/MockCollectionViewLayout.swift
@@ -12,6 +12,9 @@ final class MockCollectionViewLayout: CollectionViewLayout, Mock {
   var calls: [MockCall] = []
   var contentInsets: UIEdgeInsets = .zero
   var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] = [:]
+  var state: PagingState = .empty
+  var visibleItems = PagingItems(items: [])
+  var sizeCache: PagingSizeCache?
   
   func prepare() {
     calls.append(MockCall(

--- a/ParchmentTests/PagingIndicatorLayoutAttributesSpec.swift
+++ b/ParchmentTests/PagingIndicatorLayoutAttributesSpec.swift
@@ -10,7 +10,7 @@ class PagingIndicatorLayoutAttributesSpec: QuickSpec {
     describe("PagingIndicatorLayoutAttributes") {
       
       let layoutAttributes = PagingIndicatorLayoutAttributes()
-      let options = PagingOptions()
+      var options = PagingOptions()
       
       beforeEach {
         options.font = UIFont.systemFont(ofSize: 15)

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -91,7 +91,7 @@ class PagingViewControllerSpec: QuickSpec {
           ]
           
           pagingViewController = PagingViewController()
-          pagingViewController.menuItemSize = .fixed(width: 100, height: 50)
+          pagingViewController.options.menuItemSize = .fixed(width: 100, height: 50)
           pagingViewController.dataSource = dataSource
           
           UIApplication.shared.keyWindow!.rootViewController = pagingViewController
@@ -160,7 +160,7 @@ class PagingViewControllerSpec: QuickSpec {
             ]
             
             pagingViewController = PagingViewController()
-            pagingViewController.menuItemSize = .fixed(width: 100, height: 50)
+            pagingViewController.options.menuItemSize = .fixed(width: 100, height: 50)
             pagingViewController.dataSource = dataSource
             
             UIApplication.shared.keyWindow!.rootViewController = pagingViewController
@@ -340,7 +340,7 @@ class PagingViewControllerSpec: QuickSpec {
         
         beforeEach {
           viewController = PagingViewController()
-          viewController.menuItemSize = .fixed(width: 100, height: 50)
+          viewController.options.menuItemSize = .fixed(width: 100, height: 50)
           viewController.infiniteDataSource = dataSource
           
           UIApplication.shared.keyWindow!.rootViewController = viewController

--- a/StoryboardExample/ViewController.swift
+++ b/StoryboardExample/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     
     // Initialize a FixedPagingViewController and pass
     // in the view controllers.
-    let pagingViewController = FixedPagingViewController(viewControllers: [
+    let pagingViewController = PagingViewController(viewControllers: [
       firstViewController,
       secondViewController
     ])


### PR DESCRIPTION
This is a breaking change. Instead of setting configuration properties
directly on PagingViewController, you now need set them on the
options property.

Before: `pagingViewController.menuInsets = .zero`
After: `pagingViewController.options.menuInsets = .zero`

These changes will make it easier to add support for using the menu as
a standalone component. Internally, PagingOptions also changed from a
class type to a struct.