### PR TITLE
Move width delegate method into separate delegate object

### DIFF
--- a/DelegateExample/ViewController.swift
+++ b/DelegateExample/ViewController.swift
@@ -28,7 +28,7 @@ class ViewController: UIViewController {
     
     let pagingViewController = PagingViewController()
     pagingViewController.dataSource = self
-    pagingViewController.delegate = self
+    pagingViewController.sizeDelegate = self
     
     // Add the paging view controller as a child view controller and
     // contrain it to all edges.
@@ -56,7 +56,7 @@ extension ViewController: PagingViewControllerDataSource {
   
 }
 
-extension ViewController: PagingViewControllerDelegate {
+extension ViewController: PagingViewControllerSizeDelegate {
   
   // We want the size of our paging items to equal the width of the
   // city title. Parchment does not support self-sizing cells at
@@ -64,7 +64,7 @@ extension ViewController: PagingViewControllerDelegate {
   // can access the title string by casting the paging item to a
   // PagingTitleItem, which is the PagingItem type used by
   // FixedPagingViewController.
-  func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat? {
+  func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat {
     guard let item = pagingItem as? PagingTitleItem else { return 0 }
     
     let insets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		95D78FE322871AB800E6EE7C /* Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D78FE222871AB800E6EE7C /* Mock.swift */; };
 		95D78FEA228734A100E6EE7C /* equalItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D78FE9228734A100E6EE7C /* equalItems.swift */; };
 		95D78FEC2288343F00E6EE7C /* MockPagingControllerSizeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D78FEB2288343F00E6EE7C /* MockPagingControllerSizeDelegate.swift */; };
+		95D790102299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D7900F2299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift */; };
 		95DC71B4212E8A2B00269CDC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DC71B3212E8A2B00269CDC /* AppDelegate.swift */; };
 		95DC71B6212E8A2B00269CDC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DC71B5212E8A2B00269CDC /* ViewController.swift */; };
 		95DC71B9212E8A2B00269CDC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95DC71B7212E8A2B00269CDC /* Main.storyboard */; };
@@ -511,6 +512,7 @@
 		95D78FE222871AB800E6EE7C /* Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mock.swift; sourceTree = "<group>"; };
 		95D78FE9228734A100E6EE7C /* equalItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = equalItems.swift; sourceTree = "<group>"; };
 		95D78FEB2288343F00E6EE7C /* MockPagingControllerSizeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPagingControllerSizeDelegate.swift; sourceTree = "<group>"; };
+		95D7900F2299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingViewControllerSizeDelegate.swift; sourceTree = "<group>"; };
 		95DC71B1212E8A2B00269CDC /* ScrollExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ScrollExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95DC71B3212E8A2B00269CDC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95DC71B5212E8A2B00269CDC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -847,6 +849,7 @@
 				95E4BA6F1FF15E84008871A3 /* PagingViewControllerDataSource.swift */,
 				3E2AAD2D1CA86A320044AAA5 /* PagingViewControllerDelegate.swift */,
 				3E4189201C9573FA001E0284 /* PagingViewControllerInfiniteDataSource.swift */,
+				95D7900F2299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift */,
 				95868C33200412DE004B392B /* Tween.swift */,
 			);
 			path = Protocols;
@@ -1528,6 +1531,7 @@
 				95A0AF001FF707910043B90A /* PagingTitleItem.swift in Sources */,
 				3E49C72A1C8F5C13006269DD /* PagingViewController.swift in Sources */,
 				95A84B0D20ED46920031520F /* AnyPagingItem.swift in Sources */,
+				95D790102299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift in Sources */,
 				95E4BA701FF15E84008871A3 /* PagingViewControllerDataSource.swift in Sources */,
 				957F14091E35583500E562F8 /* PagingCellLayoutAttributes.swift in Sources */,
 				9568922B222C525C00AFF250 /* CollectionView.swift in Sources */,

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -61,11 +61,15 @@ open class PagingViewController:
   /// without having to actually allocate them before they are needed.
   public weak var infiniteDataSource: PagingViewControllerInfiniteDataSource?
   
+  /// Use this delegate to get notified when the user is scrolling or
+  /// when an item is selected.
+  public weak var delegate: PagingViewControllerDelegate?
+  
   /// Use this delegate if you want to manually control the width of
   /// your menu items. Self-sizing cells is not supported at the
   /// moment, so you have to use this if you have a custom cell that
   /// you want to size based on its content.
-  public weak var delegate: PagingViewControllerDelegate? {
+  public weak var sizeDelegate: PagingViewControllerSizeDelegate? {
     didSet {
       pagingController.sizeDelegate = self
     }
@@ -530,7 +534,7 @@ extension PagingViewController: PagingControllerDataSource {
 extension PagingViewController: PagingControllerSizeDelegate {
   
   func width(for pagingItem: PagingItem, isSelected: Bool) -> CGFloat {
-    return delegate?.pagingViewController(self, widthForPagingItem: pagingItem, isSelected: isSelected) ?? 0
+    return sizeDelegate?.pagingViewController(self, widthForPagingItem: pagingItem, isSelected: isSelected) ?? 0
   }
   
 }

--- a/Parchment/Protocols/PagingViewControllerDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The `PagingViewControllerDelegate` protocol defines methods that
 /// can used to determine when the user navigates between view
-/// controllers, or to define the width of a given `PagingItem`.
+/// controllers.
 public protocol PagingViewControllerDelegate: class {
   
   /// Called whenever a scroll transition is in progress.
@@ -50,21 +50,6 @@ public protocol PagingViewControllerDelegate: class {
     startingViewController: UIViewController?,
     destinationViewController: UIViewController,
     transitionSuccessful: Bool)
-  
-  /// Manually control the width for a given `PagingItem`. Parchment
-  /// does not support self-sizing cells, so you have to use this if
-  /// you have a cell that you want to size based on its content.
-  ///
-  /// - Parameter pagingViewController: The `PagingViewController`
-  /// instance
-  /// - Parameter pagingItem: The `PagingItem` instance
-  /// - Parameter isSelected: A boolean that indicates whether the
-  /// given `PagingItem` is selected
-  /// - Returns: The width for the `PagingItem` or nil
-  func pagingViewController(
-    _: PagingViewController,
-    widthForPagingItem pagingItem: PagingItem,
-    isSelected: Bool) -> CGFloat?
 }
 
 public extension PagingViewControllerDelegate {
@@ -94,12 +79,5 @@ public extension PagingViewControllerDelegate {
     destinationViewController: UIViewController,
     transitionSuccessful: Bool) {
     return
-  }
-  
-  func pagingViewController(
-    _ pagingViewController: PagingViewController,
-    widthForPagingItem pagingItem: PagingItem,
-    isSelected: Bool) -> CGFloat? {
-    return nil
   }
 }

--- a/Parchment/Protocols/PagingViewControllerSizeDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerSizeDelegate.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+public protocol PagingViewControllerSizeDelegate: class {
+  
+  /// Manually control the width for a given `PagingItem`. Parchment
+  /// does not support self-sizing cells, so you have to use this if
+  /// you have a cell that you want to size based on its content.
+  ///
+  /// - Parameter pagingViewController: The `PagingViewController`
+  /// instance
+  /// - Parameter pagingItem: The `PagingItem` instance
+  /// - Parameter isSelected: A boolean that indicates whether the
+  /// given `PagingItem` is selected
+  /// - Returns: The width for the `PagingItem`
+  func pagingViewController(
+    _: PagingViewController,
+    widthForPagingItem pagingItem: PagingItem,
+    isSelected: Bool) -> CGFloat
+}

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -28,10 +28,10 @@ class DataSource: PagingViewControllerInfiniteDataSource {
   
 }
 
-class Delegate: PagingViewControllerDelegate {
+class SizeDelegate: PagingViewControllerSizeDelegate {
   
-  func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat? {
-    guard let item = pagingItem as? PagingTitleItem else { return nil }
+  func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat {
+    guard let item = pagingItem as? PagingTitleItem else { return 0 }
     if item.index == 0 {
       return 100
     } else {
@@ -138,7 +138,7 @@ class PagingViewControllerSpec: QuickSpec {
       describe("reloading data") {
         
         let dataSource = ReloadingDataSource()
-        var delegate: Delegate!
+        var delegate: SizeDelegate!
         var pagingViewController: PagingViewController!
         
         context("has items before reloading") {
@@ -301,8 +301,8 @@ class PagingViewControllerSpec: QuickSpec {
           describe("width delegate") {
             
             beforeEach {
-              delegate = Delegate()
-              pagingViewController.delegate = delegate
+              delegate = SizeDelegate()
+              pagingViewController.sizeDelegate = delegate
             }
             
             it("uses the width delegate after reloading data") {

--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -144,21 +144,21 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    pagingViewController.menuItemSource = .class(type: ImagePagingCell.self)
-    pagingViewController.menuItemSize = .fixed(width: menuItemSize.width, height: menuItemSize.height)
-    pagingViewController.menuItemSpacing = 8
-    pagingViewController.menuInsets = menuInsets
-    pagingViewController.borderColor = UIColor(white: 0, alpha: 0.1)
-    pagingViewController.indicatorColor = .black
+    pagingViewController.options.menuItemSource = .class(type: ImagePagingCell.self)
+    pagingViewController.options.menuItemSize = .fixed(width: menuItemSize.width, height: menuItemSize.height)
+    pagingViewController.options.menuItemSpacing = 8
+    pagingViewController.options.menuInsets = menuInsets
+    pagingViewController.options.borderColor = UIColor(white: 0, alpha: 0.1)
+    pagingViewController.options.indicatorColor = .black
     
-    pagingViewController.indicatorOptions = .visible(
+    pagingViewController.options.indicatorOptions = .visible(
       height: 1,
       zIndex: Int.max,
       spacing: UIEdgeInsets.zero,
       insets: UIEdgeInsets.zero
     )
     
-    pagingViewController.borderOptions = .visible(
+    pagingViewController.options.borderOptions = .visible(
       height: 1,
       zIndex: Int.max - 1,
       insets: UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
@@ -195,7 +195,7 @@ class ViewController: UIViewController {
     menuView.menuHeightConstraint?.constant = height
     
     // Update the size of the menu items.
-    pagingViewController.menuItemSize = .fixed(
+    pagingViewController.options.menuItemSize = .fixed(
       width: menuItemSize.width,
       height: height - menuInsets.top - menuInsets.bottom
     )


### PR DESCRIPTION
Moves the widthForPagingItem delegate method from
`PagingViewControllerDelegate` into a new protocol called
`PagingViewControllerSizeDelegate`. The property on
`PagingViewController` is called `sizeDelegate`.