### PR TITLE
Fix issue changing selection when view is not visible

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -1110,7 +1110,7 @@ open class PagingViewController<T: PagingItem>:
       // paging item, causing it to jump to that item even if it's
       // scrolled out of view. We still need to fire an event that
       // will reset the state to .selected.
-      if state.upcomingPagingItem == nil {
+      if case .scrolling(_, nil, _, _, _)  = state {
         stateMachine.fire(.cancelScrolling)
       } else {
         stateMachine.fire(.finishScrolling)


### PR DESCRIPTION
When calling select(pagingItem:) while the view controller was not
visible, the menu items would get out of sync when navigating
back. This happened because the state never changed to .scrolling and
therefore the .cancelScrolling event was triggered. To fix this we
need to check that the state is actually .scrolling before calling the
.cancelScrolling event.