### PR TITLE
Fix unbalanced appearance transitions

### DIFF
--- a/Parchment/Classes/EMPageViewController.swift
+++ b/Parchment/Classes/EMPageViewController.swift
@@ -298,9 +298,12 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
             selectedViewController.beginAppearanceTransition(true, animated: animated)
         }
     }
+
+    private var didViewAppear: Bool = false
     
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        didViewAppear = true
         if let selectedViewController = selectedViewController {
             selectedViewController.endAppearanceTransition()
         }
@@ -315,6 +318,7 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
     
     open override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
+        didViewAppear = false
         if let selectedViewController = selectedViewController {
             selectedViewController.endAppearanceTransition()
         }
@@ -358,11 +362,13 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
             // Shift view controllers forward
             self.beforeViewController = self.selectedViewController
             self.selectedViewController = self.afterViewController
-            
-            self.selectedViewController!.endAppearanceTransition()
-            
+          
             self.removeChildIfNeeded(self.beforeViewController)
-            self.beforeViewController?.endAppearanceTransition()
+          
+            if didViewAppear {
+                self.selectedViewController?.endAppearanceTransition()
+                self.beforeViewController?.endAppearanceTransition()
+            }
             
             self.delegate?.em_pageViewController?(self, didFinishScrollingFrom: self.beforeViewController, destinationViewController: self.selectedViewController!, transitionSuccessful: true)
             
@@ -385,11 +391,13 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
             // Shift view controllers reverse
             self.afterViewController = self.selectedViewController
             self.selectedViewController = self.beforeViewController
-            
-            self.selectedViewController!.endAppearanceTransition()
-            
+          
             self.removeChildIfNeeded(self.afterViewController)
-            self.afterViewController?.endAppearanceTransition()
+          
+            if didViewAppear {
+                self.selectedViewController?.endAppearanceTransition()
+                self.afterViewController?.endAppearanceTransition()
+            }
             
             self.delegate?.em_pageViewController?(self, didFinishScrollingFrom: self.afterViewController!, destinationViewController: self.selectedViewController!, transitionSuccessful: true)
             
@@ -415,8 +423,10 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
             } else if (self.navigationDirection == .reverse) {
                 self.beforeViewController!.beginAppearanceTransition(false, animated: self.transitionAnimated)
             }
-            
-            self.selectedViewController!.endAppearanceTransition()
+          
+            if didViewAppear {
+                self.selectedViewController?.endAppearanceTransition()
+            }
             
             // Remove hidden view controllers
             self.removeChildIfNeeded(self.beforeViewController)


### PR DESCRIPTION
When rendering the view controllers we call endAppearanceTransition,
but we also call this in viewDidAppear to make sure we forward the
correct events. This causes the same event to be triggered twice. We
need to check that the view has already appeared before triggering
endAppearanceTransition outside of viewDidAppear.