### PR TITLE
Allow menu to be used as a standalone component

### DIFF
--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -145,6 +145,9 @@
 		95D78FEA228734A100E6EE7C /* equalItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D78FE9228734A100E6EE7C /* equalItems.swift */; };
 		95D78FEC2288343F00E6EE7C /* MockPagingControllerSizeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D78FEB2288343F00E6EE7C /* MockPagingControllerSizeDelegate.swift */; };
 		95D790102299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D7900F2299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift */; };
+		95D790142299D28A00E6EE7C /* PagingMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D790132299D28A00E6EE7C /* PagingMenuView.swift */; };
+		95D790162299D56300E6EE7C /* PagingMenuDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D790152299D56300E6EE7C /* PagingMenuDataSource.swift */; };
+		95D790182299D57A00E6EE7C /* PagingMenuDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D790172299D57A00E6EE7C /* PagingMenuDelegate.swift */; };
 		95DC71B4212E8A2B00269CDC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DC71B3212E8A2B00269CDC /* AppDelegate.swift */; };
 		95DC71B6212E8A2B00269CDC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95DC71B5212E8A2B00269CDC /* ViewController.swift */; };
 		95DC71B9212E8A2B00269CDC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95DC71B7212E8A2B00269CDC /* Main.storyboard */; };
@@ -513,6 +516,9 @@
 		95D78FE9228734A100E6EE7C /* equalItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = equalItems.swift; sourceTree = "<group>"; };
 		95D78FEB2288343F00E6EE7C /* MockPagingControllerSizeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPagingControllerSizeDelegate.swift; sourceTree = "<group>"; };
 		95D7900F2299CE6100E6EE7C /* PagingViewControllerSizeDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingViewControllerSizeDelegate.swift; sourceTree = "<group>"; };
+		95D790132299D28A00E6EE7C /* PagingMenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingMenuView.swift; sourceTree = "<group>"; };
+		95D790152299D56300E6EE7C /* PagingMenuDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingMenuDataSource.swift; sourceTree = "<group>"; };
+		95D790172299D57A00E6EE7C /* PagingMenuDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingMenuDelegate.swift; sourceTree = "<group>"; };
 		95DC71B1212E8A2B00269CDC /* ScrollExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ScrollExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95DC71B3212E8A2B00269CDC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		95DC71B5212E8A2B00269CDC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -718,6 +724,7 @@
 				3E4090AC1C88BDD100800E22 /* PagingIndicatorLayoutAttributes.swift */,
 				3E49C7221C8F5C13006269DD /* PagingIndicatorView.swift */,
 				954842581F42438E0072038C /* PagingInvalidationContext.swift */,
+				95D790132299D28A00E6EE7C /* PagingMenuView.swift */,
 				3E4090981C88BCC900800E22 /* PagingOptions.swift */,
 				955444B01FC99E2C001EC26B /* PagingSizeCache.swift */,
 				95A84B0420E586FA0031520F /* PagingStaticDataSource.swift */,
@@ -846,6 +853,8 @@
 				9568922A222C525C00AFF250 /* CollectionView.swift */,
 				3E2AAD2B1CA869B50044AAA5 /* PagingItem.swift */,
 				95A52A141FF81F70002A2ED4 /* PagingLayout.swift */,
+				95D790152299D56300E6EE7C /* PagingMenuDataSource.swift */,
+				95D790172299D57A00E6EE7C /* PagingMenuDelegate.swift */,
 				95E4BA6F1FF15E84008871A3 /* PagingViewControllerDataSource.swift */,
 				3E2AAD2D1CA86A320044AAA5 /* PagingViewControllerDelegate.swift */,
 				3E4189201C9573FA001E0284 /* PagingViewControllerInfiniteDataSource.swift */,
@@ -1551,6 +1560,7 @@
 				3E40909C1C88BCC900800E22 /* PagingOptions.swift in Sources */,
 				3E4090B11C88BDD100800E22 /* PagingIndicatorLayoutAttributes.swift in Sources */,
 				955444C41FC9CD2C001EC26B /* PagingMenuInteraction.swift in Sources */,
+				95D790142299D28A00E6EE7C /* PagingMenuView.swift in Sources */,
 				95F5660F2128707900F2A75E /* PagingMenuItemSource.swift in Sources */,
 				952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */,
 				955444BC1FC9CCD9001EC26B /* PagingBorderOptions.swift in Sources */,
@@ -1561,7 +1571,9 @@
 				95B301171E59FCD500B95D02 /* UIEdgeInsets.swift in Sources */,
 				955444C01FC9CCFF001EC26B /* PagingMenuHorizontalAlignment.swift in Sources */,
 				3E49C7261C8F5C13006269DD /* PagingCell.swift in Sources */,
+				95D790162299D56300E6EE7C /* PagingMenuDataSource.swift in Sources */,
 				955444BA1FC9CCBF001EC26B /* PagingIndicatorOptions.swift in Sources */,
+				95D790182299D57A00E6EE7C /* PagingMenuDelegate.swift in Sources */,
 				3E49C72E1C8F5CCE006269DD /* PagingCellViewModel.swift in Sources */,
 				95868C2C2003DA87004B392B /* PagingContentInteraction.swift in Sources */,
 				955444B81FC9CCA6001EC26B /* PagingMenuItemSize.swift in Sources */,

--- a/Parchment/Classes/PagingController.swift
+++ b/Parchment/Classes/PagingController.swift
@@ -1,26 +1,14 @@
 import UIKit
 
-protocol PagingControllerDataSource: class {
-  func pagingItemBefore(pagingItem: PagingItem) -> PagingItem?
-  func pagingItemAfter(pagingItem: PagingItem) -> PagingItem?
-}
-
-protocol PagingControllerDelegate: class {
-  func selectContent(pagingItem: PagingItem, direction: PagingDirection, animated: Bool)
-  func selectContentPrevious(animated: Bool)
-  func selectContentNext(animated: Bool)
-  func removeContent()
-}
-
 protocol PagingControllerSizeDelegate: class {
   func width(for: PagingItem, isSelected: Bool) -> CGFloat
 }
 
 final class PagingController: NSObject {
   
-  weak var dataSource: PagingControllerDataSource?
+  weak var dataSource: PagingMenuDataSource?
   weak var sizeDelegate: PagingControllerSizeDelegate?
-  weak var delegate: PagingControllerDelegate?
+  weak var delegate: PagingMenuDelegate?
 
   weak var collectionView: CollectionView! {
     didSet {
@@ -108,12 +96,6 @@ final class PagingController: NSObject {
     case .selected:
       if let currentPagingItem = state.currentPagingItem {
         if pagingItem.isEqual(to: currentPagingItem) == false {
-          
-          let direction = visibleItems.direction(
-            from: currentPagingItem,
-            to: pagingItem
-          )
-          
           appendItemsIfNeeded(upcomingPagingItem: pagingItem)
           
           let transition = calculateTransition(
@@ -129,19 +111,16 @@ final class PagingController: NSObject {
             distance: transition.distance
           )
           
-          if let upcomingItem = dataSource?.pagingItemAfter(pagingItem: currentPagingItem),
-            pagingItem.isEqual(to: upcomingItem)  {
-            delegate?.selectContentNext(animated: animated)
-          } else if let upcomingItem = dataSource?.pagingItemBefore(pagingItem: currentPagingItem),
-            pagingItem.isEqual(to: upcomingItem) {
-            delegate?.selectContentPrevious(animated: animated)
-          } else {
-            delegate?.selectContent(
-              pagingItem: pagingItem,
-              direction: direction,
-              animated: animated
-            )
-          }
+          let direction = visibleItems.direction(
+            from: currentPagingItem,
+            to: pagingItem
+          )
+          
+          delegate?.selectContent(
+            pagingItem: pagingItem,
+            direction: direction,
+            animated: animated
+          )
         }
       }
       

--- a/Parchment/Classes/PagingMenuView.swift
+++ b/Parchment/Classes/PagingMenuView.swift
@@ -1,0 +1,148 @@
+import UIKit
+
+open class PagingMenuView: UIView {
+  
+  public weak var delegate: PagingMenuDelegate? {
+    didSet {
+      pagingController.delegate = delegate
+    }
+  }
+  
+  public weak var dataSource: PagingMenuDataSource? {
+    didSet {
+      pagingController.dataSource = dataSource
+    }
+  }
+  
+  /// The current state of the menu items. Indicates whether an item
+  /// is currently selected or is scrolling to another item. Can be
+  /// used to get the distance and progress of any ongoing transition.
+  public var state: PagingState {
+    return pagingController.state
+  }
+  
+  /// The `PagingItem`'s that are currently visible in the collection
+  /// view. The items in this array are not necessarily the same as
+  /// the `visibleCells` property on `UICollectionView`.
+  public var visibleItems: PagingItems {
+    return pagingController.visibleItems
+  }
+  
+  /// A custom collection view layout that lays out all the menu items
+  /// horizontally. You can customize the behavior of the layout by
+  /// setting the customization properties on `PagingViewController`.
+  /// You can also use your own subclass of the layout by defining the
+  /// `menuLayoutClass` property.
+  public private(set) lazy var collectionViewLayout: PagingCollectionViewLayout = {
+    return createLayout(layout: options.menuLayoutClass.self)
+  }()
+  
+  /// Used to display the menu items that scrolls along with the
+  /// content. Using a collection view means you can create custom
+  /// cells that display pretty much anything. By default, scrolling
+  /// is enabled in the collection view.
+  public lazy var collectionView: UICollectionView = {
+    return UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
+  }()
+  
+  /// An instance that stores all the customization so that it's
+  /// easier to share between other classes.
+  public var options = PagingOptions() {
+    didSet {
+      if options.menuLayoutClass != oldValue.menuLayoutClass {
+        let layout = createLayout(layout: options.menuLayoutClass.self)
+        collectionViewLayout = layout
+        collectionViewLayout.options = options
+        collectionView.setCollectionViewLayout(layout, animated: false)
+      }
+      else {
+        collectionViewLayout.options = options
+      }
+      
+      pagingController.options = options
+    }
+  }
+  
+  // MARK: Private Properties
+  
+  private lazy var pagingController = PagingController(options: options)
+  
+  // MARK: Initializers
+  
+  /// Creates an instance of `PagingViewController`. You need to call
+  /// `select(pagingItem:animated:)` in order to set the initial view
+  /// controller before any items become visible.
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+    configure()
+  }
+  
+  required public init?(coder: NSCoder) {
+    super.init(coder: coder)
+    configure()
+  }
+  
+  // TODO: Figure out how we can remove this method.
+  open func viewAppeared() {
+    pagingController.viewAppeared()
+  }
+  
+  open func transitionSize() {
+    pagingController.transitionSize()
+  }
+  
+  open func contentScrolled(progress: CGFloat) {
+    pagingController.contentScrolled(progress: progress)
+  }
+  
+  open func contentFinishedScrolling() {
+    pagingController.contentFinishedScrolling()
+  }
+  
+  /// Reload data around given paging item. This will set the given
+  /// paging item as selected and generate new items around it.
+  ///
+  /// - Parameter pagingItem: The `PagingItem` that will be selected
+  /// after the data reloads.
+  open func reload(around pagingItem: PagingItem) {
+    pagingController.reloadMenu(around: pagingItem)
+  }
+  
+  /// Selects a given paging item. This need to be called after you
+  /// initilize the `PagingViewController` to set the initial
+  /// `PagingItem`. This can be called both before and after the view
+  /// has been loaded. You can also use this to programmatically
+  /// navigate to another `PagingItem`.
+  ///
+  /// - Parameter pagingItem: The `PagingItem` to be displayed.
+  /// - Parameter animated: A boolean value that indicates whether
+  /// the transtion should be animated. Default is false.
+  open func select(pagingItem: PagingItem, animated: Bool = false) {
+    pagingController.select(pagingItem: pagingItem, animated: animated)
+  }
+  
+  // MARK: Private Methods
+  
+  private func configure() {
+    collectionView.backgroundColor = options.menuBackgroundColor
+    collectionView.delegate = self
+    addSubview(collectionView)
+    constrainToEdges(collectionView)
+    
+    pagingController.collectionView = collectionView
+    pagingController.collectionViewLayout = collectionViewLayout
+  }
+  
+}
+
+extension PagingMenuView: UICollectionViewDelegate {
+  
+  public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    pagingController.menuScrolled()
+  }
+  
+  public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    pagingController.select(indexPath: indexPath, animated: true)
+  }
+  
+}

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -519,13 +519,13 @@ open class PagingViewController:
   }
 }
 
-extension PagingViewController: PagingControllerDataSource {
+extension PagingViewController: PagingMenuDataSource {
   
-  func pagingItemBefore(pagingItem: PagingItem) -> PagingItem? {
+  public func pagingItemBefore(pagingItem: PagingItem) -> PagingItem? {
     return infiniteDataSource?.pagingViewController(self, itemBefore: pagingItem)
   }
   
-  func pagingItemAfter(pagingItem: PagingItem) -> PagingItem? {
+  public func pagingItemAfter(pagingItem: PagingItem) -> PagingItem? {
     return infiniteDataSource?.pagingViewController(self, itemAfter: pagingItem)
   }
   
@@ -539,29 +539,31 @@ extension PagingViewController: PagingControllerSizeDelegate {
   
 }
 
-extension PagingViewController: PagingControllerDelegate {
+extension PagingViewController: PagingMenuDelegate {
   
-  func selectContent(pagingItem: PagingItem, direction: PagingDirection, animated: Bool) {
+  public func selectContent(pagingItem: PagingItem, direction: PagingDirection, animated: Bool) {
     guard let dataSource = infiniteDataSource else { return }
-    pageViewController.selectViewController(
-      dataSource.pagingViewController(self, viewControllerFor: pagingItem),
-      direction: direction.pageViewControllerNavigationDirection,
-      animated: animated,
-      completion: nil
-    )
+    
+    switch direction {
+    case .forward(true):
+      pageViewController.scrollForward(animated: animated, completion: nil)
+      pageViewController.view.layoutIfNeeded()
+      
+    case .reverse(true):
+      pageViewController.scrollReverse(animated: animated, completion: nil)
+      pageViewController.view.layoutIfNeeded()
+      
+    default:
+      pageViewController.selectViewController(
+        dataSource.pagingViewController(self, viewControllerFor: pagingItem),
+        direction: direction.pageViewControllerNavigationDirection,
+        animated: animated,
+        completion: nil
+      )
+    }
   }
   
-  func selectContentPrevious(animated: Bool) {
-    pageViewController.scrollReverse(animated: animated, completion: nil)
-    pageViewController.view.layoutIfNeeded()
-  }
-  
-  func selectContentNext(animated: Bool) {
-    pageViewController.scrollForward(animated: animated, completion: nil)
-    pageViewController.view.layoutIfNeeded()
-  }
-  
-  func removeContent() {
+  public func removeContent() {
     pageViewController.removeAllViewControllers()
   }
   

--- a/Parchment/Enums/PagingDirection.swift
+++ b/Parchment/Enums/PagingDirection.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-public enum PagingDirection {
-  case reverse
-  case forward
+public enum PagingDirection: Equatable {
+  case reverse(sibling: Bool)
+  case forward(sibling: Bool)
   case none
 }
 

--- a/Parchment/Protocols/PagingMenuDataSource.swift
+++ b/Parchment/Protocols/PagingMenuDataSource.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol PagingMenuDataSource: class {
+  func pagingItemBefore(pagingItem: PagingItem) -> PagingItem?
+  func pagingItemAfter(pagingItem: PagingItem) -> PagingItem?
+}

--- a/Parchment/Protocols/PagingMenuDelegate.swift
+++ b/Parchment/Protocols/PagingMenuDelegate.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol PagingMenuDelegate: class {
+  func selectContent(pagingItem: PagingItem, direction: PagingDirection, animated: Bool)
+  func removeContent()
+}

--- a/Parchment/Structs/PagingItems.swift
+++ b/Parchment/Structs/PagingItems.swift
@@ -53,11 +53,26 @@ public struct PagingItems {
     if contains(from) == false {
       return .none
     } else if from.isBefore(item: to) {
-      return .forward
+      return .forward(sibling: isSibling(from: from, to: to))
     } else if to.isBefore(item: from) {
-      return .reverse
+      return .reverse(sibling: isSibling(from: from, to: to))
     }
     return .none
+  }
+  
+  func isSibling(from: PagingItem, to: PagingItem) -> Bool {
+    guard
+      let fromIndex = items.firstIndex(where : { $0.isEqual(to: from) }),
+      let toIndex = items.firstIndex(where: { $0.isEqual(to: to) })
+      else { return false }
+    
+    if fromIndex == toIndex - 1 {
+      return true
+    } else if fromIndex - 1 == toIndex {
+      return true
+    } else {
+      return false
+    }
   }
   
   func contains(_ pagingItem: PagingItem) -> Bool {

--- a/ParchmentTests/Mocks/MockPagingControllerDataSource.swift
+++ b/ParchmentTests/Mocks/MockPagingControllerDataSource.swift
@@ -1,7 +1,7 @@
 import Foundation
 @testable import Parchment
 
-final class MockPagingControllerDataSource: PagingControllerDataSource {
+final class MockPagingControllerDataSource: PagingMenuDataSource {
   
   var maxIndexAfter: Int = Int.max
   var minIndexBefore: Int = Int.min

--- a/ParchmentTests/Mocks/MockPagingControllerDelegate.swift
+++ b/ParchmentTests/Mocks/MockPagingControllerDelegate.swift
@@ -1,12 +1,10 @@
 import Foundation
 @testable import Parchment
 
-final class MockPagingControllerDelegate: PagingControllerDelegate, Mock {
+final class MockPagingControllerDelegate: PagingMenuDelegate, Mock {
   
   enum Action: Equatable {
     case selectContent(pagingItem: Item, direction: PagingDirection, animated: Bool)
-    case selectContentPrevious(animated: Bool)
-    case selectContentNext(animated: Bool)
     case removeContent
   }
   
@@ -20,20 +18,6 @@ final class MockPagingControllerDelegate: PagingControllerDelegate, Mock {
         direction: direction,
         animated: animated
       ))
-    ))
-  }
-  
-  func selectContentPrevious(animated: Bool) {
-    calls.append(MockCall(
-      datetime: Date(),
-      action: .delegate(.selectContentPrevious(animated: animated))
-    ))
-  }
-  
-  func selectContentNext(animated: Bool) {
-    calls.append(MockCall(
-      datetime: Date(),
-      action: .delegate(.selectContentNext(animated: animated))
     ))
   }
   

--- a/ParchmentTests/PagingControllerSpec.swift
+++ b/ParchmentTests/PagingControllerSpec.swift
@@ -574,7 +574,11 @@ class PagingControllerSpec: QuickSpec {
               expect(collectionView.calls).to(beEmpty())
               expect(collectionViewLayout.calls).to(beEmpty())
               expect(actions(delegate.calls)).to(equal([
-                .delegate(.selectContentPrevious(animated: false))
+                .delegate(.selectContent(
+                  pagingItem: Item(index: 0),
+                  direction: .reverse(sibling: true),
+                  animated: false
+                ))
               ]))
             }
           }
@@ -586,7 +590,11 @@ class PagingControllerSpec: QuickSpec {
               expect(collectionView.calls).to(beEmpty())
               expect(collectionViewLayout.calls).to(beEmpty())
               expect(actions(delegate.calls)).to(equal([
-                .delegate(.selectContentNext(animated: false))
+                .delegate(.selectContent(
+                  pagingItem: Item(index: 2),
+                  direction: .forward(sibling: true),
+                  animated: false
+                ))
               ]))
             }
           }
@@ -600,7 +608,7 @@ class PagingControllerSpec: QuickSpec {
               expect(actions(delegate.calls)).to(equal([
                 .delegate(.selectContent(
                   pagingItem: Item(index: 4),
-                  direction: .forward,
+                  direction: .forward(sibling: false),
                   animated: false
                 ))
               ]))
@@ -664,7 +672,11 @@ class PagingControllerSpec: QuickSpec {
                 .collectionViewLayout(.prepare),
                 .collectionView(.contentOffset(CGPoint(x: 400, y: 0))),
                 .collectionView(.layoutIfNeeded),
-                .delegate(.selectContentNext(animated: false))
+                .delegate(.selectContent(
+                  pagingItem: Item(index: 1),
+                  direction: .forward(sibling: true),
+                  animated: false
+                ))
               ]
             ))
           }
@@ -875,7 +887,7 @@ class PagingControllerSpec: QuickSpec {
               pagingItem: Item(index: 2),
               direction: .none,
               animated: false
-              )),
+            )),
             .collectionViewLayout(.invalidateLayout)
           ]
         ))

--- a/ParchmentTests/PagingDataStructureSpec.swift
+++ b/ParchmentTests/PagingDataStructureSpec.swift
@@ -50,7 +50,7 @@ class PagingDataSpec: QuickSpec {
               let currentPagingItem = Item(index: 0)
               let upcomingPagingItem = Item(index: 1)
               let direction = visibleItems.direction(from: currentPagingItem, to: upcomingPagingItem)
-              expect(direction).to(equal(PagingDirection.forward))
+              expect(direction).to(equal(PagingDirection.forward(sibling: true)))
             }
           }
           
@@ -59,7 +59,7 @@ class PagingDataSpec: QuickSpec {
               let currentPagingItem = Item(index: 1)
               let upcomingPagingItem = Item(index: 0)
               let direction = visibleItems.direction(from: currentPagingItem, to: upcomingPagingItem)
-              expect(direction).to(equal(PagingDirection.reverse))
+              expect(direction).to(equal(PagingDirection.reverse(sibling: true)))
             }
           }
           


### PR DESCRIPTION
Having the menu as a separate component allows you to use it without
having to use a PageViewController for your content. For instance,
this allows you to use menu alongside a UITableView or use your own
custom page view controller implementation.