### PR TITLE
Issues when compiled as SPM dependency (Xcode 11)

### DIFF
--- a/Parchment/Classes/IndexedPagingDataSource.swift
+++ b/Parchment/Classes/IndexedPagingDataSource.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 class IndexedPagingDataSource<T: PagingItem>:
   PagingViewControllerInfiniteDataSource where T: Hashable & Comparable {

--- a/Parchment/Classes/PagingSizeCache.swift
+++ b/Parchment/Classes/PagingSizeCache.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 class PagingSizeCache<T: PagingItem>  where T: Hashable & Comparable {
   

--- a/Parchment/Classes/PagingStateMachine.swift
+++ b/Parchment/Classes/PagingStateMachine.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 class PagingStateMachine<T: PagingItem> where T: Equatable {
   

--- a/Parchment/Enums/PagingEvent.swift
+++ b/Parchment/Enums/PagingEvent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 enum PagingEvent<T: PagingItem> where T: Equatable {
   case scroll(progress: CGFloat)

--- a/Parchment/Enums/PagingMenuItemSize.swift
+++ b/Parchment/Enums/PagingMenuItemSize.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 public enum PagingMenuItemSize {
   case fixed(width: CGFloat, height: CGFloat)

--- a/Parchment/Enums/PagingMenuItemSource.swift
+++ b/Parchment/Enums/PagingMenuItemSource.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 public enum PagingMenuItemSource {
 	case `class`(type: PagingCell.Type)

--- a/Parchment/Enums/PagingState.swift
+++ b/Parchment/Enums/PagingState.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 /// The current state of the menu items. Indicates whether an item
 /// is currently selected or is scrolling to another item. Can be

--- a/Parchment/Protocols/PagingViewControllerDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerDelegate.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 /// The `PagingViewControllerDelegate` protocol defines methods that
 /// can used to determine when the user navigates between view

--- a/Parchment/Protocols/Tween.swift
+++ b/Parchment/Protocols/Tween.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 func tween(from: CGFloat, to: CGFloat, progress: CGFloat) -> CGFloat {
   return ((to - from) * progress) + from

--- a/Parchment/Structs/PagingCellViewModel.swift
+++ b/Parchment/Structs/PagingCellViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 struct PagingTitleCellViewModel {
   let title: String?

--- a/Parchment/Structs/PagingDistance.swift
+++ b/Parchment/Structs/PagingDistance.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 struct PagingDistance<T: PagingItem> where T: Hashable & Comparable {
   

--- a/Parchment/Structs/PagingIndicatorMetric.swift
+++ b/Parchment/Structs/PagingIndicatorMetric.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 struct PagingIndicatorMetric {
   


### PR DESCRIPTION
Some missing imports of UIKit let SPM fail to compile Parchment.
I added all imports to be able to use Parchment as a dependency.