### PR TITLE
Proposal: Add delegate method for telling tab selected event

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -997,6 +997,7 @@ open class PagingViewController<T: PagingItem>:
       pagingItem: selectedPagingItem,
       direction: direction,
       animated: true))
+    delegate?.pagingViewController(self, didSelectPagingCellAt: indexPath.item)
   }
   
   open func collectionView(_ collectionView: UICollectionView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -997,7 +997,10 @@ open class PagingViewController<T: PagingItem>:
       pagingItem: selectedPagingItem,
       direction: direction,
       animated: true))
-    delegate?.pagingViewController(self, didSelectPagingCellAt: indexPath.item)
+    delegate?.pagingViewController(self,
+                                   didSelectPagingCellAt: indexPath.item,
+                                   selectedItem: selectedPagingItem,
+                                   currentItem: currentPagingItem)
   }
   
   open func collectionView(_ collectionView: UICollectionView, targetContentOffsetForProposedContentOffset proposedContentOffset: CGPoint) -> CGPoint {

--- a/Parchment/Protocols/PagingViewControllerDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerDelegate.swift
@@ -70,9 +70,13 @@ public protocol PagingViewControllerDelegate: class {
   /// Called when paging cell is selected
   /// - Parameter pagingViewController: The `PagingViewController` instance
   /// - Parameter index: The index for selected paging cell
+  /// - Parameter selectedItem: The selected item
+  /// - Parameter currenItem: The current item
   func pagingViewController<T>(
     _ pagingViewController: PagingViewController<T>,
-    didSelectPagingCellAt index: Int)
+    didSelectPagingCellAt index: Int,
+    selectedItem: T,
+    currentItem: T)
   
 }
 
@@ -114,7 +118,9 @@ public extension PagingViewControllerDelegate {
   
   func pagingViewController<T>(
     _ pagingViewController: PagingViewController<T>,
-    didSelectPagingCellAt index: Int) {
+    didSelectPagingCellAt index: Int,
+    selectedItem: T,
+    currentItem: T) {
     return
   }
   

--- a/Parchment/Protocols/PagingViewControllerDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerDelegate.swift
@@ -66,6 +66,14 @@ public protocol PagingViewControllerDelegate: class {
     _ pagingViewController: PagingViewController<T>,
     widthForPagingItem pagingItem: T,
     isSelected: Bool) -> CGFloat?
+  
+  /// Called when paging cell is selected
+  /// - Parameter pagingViewController: The `PagingViewController` instance
+  /// - Parameter index: The index for selected paging cell
+  func pagingViewController<T>(
+    _ pagingViewController: PagingViewController<T>,
+    didSelectPagingCellAt index: Int)
+  
 }
 
 public extension PagingViewControllerDelegate {
@@ -103,4 +111,11 @@ public extension PagingViewControllerDelegate {
     isSelected: Bool) -> CGFloat? {
     return nil
   }
+  
+  func pagingViewController<T>(
+    _ pagingViewController: PagingViewController<T>,
+    didSelectPagingCellAt index: Int) {
+    return
+  }
+  
 }


### PR DESCRIPTION
In some cases,  It is useful to be able to get tab selected event even if the same index to currently selected index is selected.  For example, using it to scroll top or refresh data. so I would propose this delegate method.