### PR TITLE
Revert moving customization properties into PagingOptions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-test:
     macos:
-      xcode: "10.3.0"
+      xcode: "11.1.0"
     steps:
       - checkout
       - run:
@@ -10,7 +10,7 @@ jobs:
           command: carthage bootstrap --use-ssh --platform ios
       - run:
           name: Run Tests
-          command: xcodebuild -project Parchment.xcodeproj -scheme "Parchment" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone X,OS=12.4' test
+          command: xcodebuild -project Parchment.xcodeproj -scheme "Parchment" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.1' test
           
 workflows:
   version: 2

--- a/CalendarExample/ViewController.swift
+++ b/CalendarExample/ViewController.swift
@@ -28,10 +28,10 @@ class ViewController: UIViewController {
 
     let pagingViewController = PagingViewController()
     pagingViewController.register(CalendarPagingCell.self, for: CalendarItem.self)
-    pagingViewController.options.menuItemSize = .fixed(width: 48, height: 58)
-    pagingViewController.options.textColor = UIColor(red: 95/255, green: 102/255, blue: 108/255, alpha: 1)
-    pagingViewController.options.selectedTextColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
-    pagingViewController.options.indicatorColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
+    pagingViewController.menuItemSize = .fixed(width: 48, height: 58)
+    pagingViewController.textColor = UIColor(red: 95/255, green: 102/255, blue: 108/255, alpha: 1)
+    pagingViewController.selectedTextColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
+    pagingViewController.indicatorColor = UIColor(red: 117/255, green: 111/255, blue: 216/255, alpha: 1)
     
     // Add the paging view controller as a child view
     // controller and constrain it to all edges

--- a/HeaderExample/ViewController.swift
+++ b/HeaderExample/ViewController.swift
@@ -75,9 +75,9 @@ class ViewController: UIViewController {
     pagingViewController.didMove(toParent: self)
     
     // Customize the menu styling.
-    pagingViewController.options.selectedTextColor = .black
-    pagingViewController.options.indicatorColor = .black
-    pagingViewController.options.indicatorOptions = .visible(
+    pagingViewController.selectedTextColor = .black
+    pagingViewController.indicatorColor = .black
+    pagingViewController.indicatorOptions = .visible(
       height: 1,
       zIndex: Int.max,
       spacing: .zero,

--- a/IconsExample/ViewController.swift
+++ b/IconsExample/ViewController.swift
@@ -50,10 +50,10 @@ class ViewController: UIViewController {
     
     let pagingViewController = PagingViewController()
     pagingViewController.register(IconPagingCell.self, for: IconItem.self)
-    pagingViewController.options.menuItemSize = .fixed(width: 60, height: 60)
-    pagingViewController.options.textColor = UIColor(red: 0.51, green: 0.54, blue: 0.56, alpha: 1)
-    pagingViewController.options.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
-    pagingViewController.options.indicatorColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
+    pagingViewController.menuItemSize = .fixed(width: 60, height: 60)
+    pagingViewController.textColor = UIColor(red: 0.51, green: 0.54, blue: 0.56, alpha: 1)
+    pagingViewController.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
+    pagingViewController.indicatorColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
     pagingViewController.dataSource = self
     pagingViewController.select(pagingItem: IconItem(icon: icons[0], index: 0))
     

--- a/LargeTitlesExample/ViewController.swift
+++ b/LargeTitlesExample/ViewController.swift
@@ -59,12 +59,12 @@ class ViewController: UIViewController {
         guard let navigationController = navigationController else { return }
         
         // Customize the menu to match the navigation bar color
-        pagingViewController.options.menuBackgroundColor = UIColor(red: 85/255, green: 66/255, blue: 232/255, alpha: 1)
-        pagingViewController.options.menuItemSize = .fixed(width: 150, height: 30)
-        pagingViewController.options.textColor = UIColor.white.withAlphaComponent(0.7)
-        pagingViewController.options.selectedTextColor = UIColor.white
-        pagingViewController.options.borderOptions = .hidden
-        pagingViewController.options.indicatorColor = UIColor(red: 10/255, green: 0, blue: 105/255, alpha: 1)
+        pagingViewController.menuBackgroundColor = UIColor(red: 85/255, green: 66/255, blue: 232/255, alpha: 1)
+        pagingViewController.menuItemSize = .fixed(width: 150, height: 30)
+        pagingViewController.textColor = UIColor.white.withAlphaComponent(0.7)
+        pagingViewController.selectedTextColor = UIColor.white
+        pagingViewController.borderOptions = .hidden
+        pagingViewController.indicatorColor = UIColor(red: 10/255, green: 0, blue: 105/255, alpha: 1)
         
         // Add the "hidden" scroll view to the root of the UIViewController.
         view.addSubview(hiddenScrollView)

--- a/MultipleCellsExample/ViewController.swift
+++ b/MultipleCellsExample/ViewController.swift
@@ -35,10 +35,10 @@ class ViewController: UIViewController {
         pagingViewController.sizeDelegate = self
         pagingViewController.register(IconPagingCell.self, for: IconItem.self)
         pagingViewController.register(PagingTitleCell.self, for: PagingTitleItem.self)
-        pagingViewController.options.menuItemSize = .fixed(width: 60, height: 60)
-        pagingViewController.options.textColor = UIColor(red: 0.51, green: 0.54, blue: 0.56, alpha: 1)
-        pagingViewController.options.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
-        pagingViewController.options.indicatorColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
+        pagingViewController.menuItemSize = .fixed(width: 60, height: 60)
+        pagingViewController.textColor = UIColor(red: 0.51, green: 0.54, blue: 0.56, alpha: 1)
+        pagingViewController.selectedTextColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
+        pagingViewController.indicatorColor = UIColor(red: 0.14, green: 0.77, blue: 0.85, alpha: 1)
         pagingViewController.dataSource = self
         pagingViewController.select(index: 0)
         

--- a/NavigationBarExample/ViewController.swift
+++ b/NavigationBarExample/ViewController.swift
@@ -39,11 +39,11 @@ class ViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    pagingViewController.options.borderOptions = .hidden
-    pagingViewController.options.menuBackgroundColor = .clear
-    pagingViewController.options.indicatorColor = UIColor(white: 0, alpha: 0.4)
-    pagingViewController.options.textColor = UIColor(white: 1, alpha: 0.6)
-    pagingViewController.options.selectedTextColor = .white
+    pagingViewController.borderOptions = .hidden
+    pagingViewController.menuBackgroundColor = .clear
+    pagingViewController.indicatorColor = UIColor(white: 0, alpha: 0.4)
+    pagingViewController.textColor = UIColor(white: 1, alpha: 0.6)
+    pagingViewController.selectedTextColor = .white
     
     // Make sure you add the PagingViewController as a child view
     // controller and contrain it to the edges of the view.
@@ -62,7 +62,7 @@ class ViewController: UIViewController {
     super.viewDidLayoutSubviews()
     guard let navigationBar = navigationController?.navigationBar else { return }
     navigationItem.titleView?.frame = CGRect(origin: .zero, size: navigationBar.bounds.size)
-    pagingViewController.options.menuItemSize = .fixed(width: 100, height: navigationBar.bounds.height)
+    pagingViewController.menuItemSize = .fixed(width: 100, height: navigationBar.bounds.height)
   }
   
 }

--- a/Parchment/Classes/PagingMenuView.swift
+++ b/Parchment/Classes/PagingMenuView.swift
@@ -2,6 +2,163 @@ import UIKit
 
 open class PagingMenuView: UIView {
   
+  // MARK: Public Properties
+  
+  /// The size for each of the menu items. _Default:
+  /// .sizeToFit(minWidth: 150, height: 40)_
+  public var menuItemSize: PagingMenuItemSize {
+    get { return options.menuItemSize }
+    set { options.menuItemSize = newValue }
+  }
+    
+  /// Determine the spacing between the menu items. _Default: 0_
+  public var menuItemSpacing: CGFloat {
+    get { return options.menuItemSpacing }
+    set { options.menuItemSpacing = newValue }
+  }
+  
+  /// Determine the insets at around all the menu items. _Default:
+  /// UIEdgeInsets.zero_
+  public var menuInsets: UIEdgeInsets {
+    get { return options.menuInsets }
+    set { options.menuInsets = newValue }
+  }
+  
+  /// Determine whether the menu items should be centered when all the
+  /// items can fit within the bounds of the view. _Default: .left_
+  public var menuHorizontalAlignment: PagingMenuHorizontalAlignment {
+    get { return options.menuHorizontalAlignment }
+    set { options.menuHorizontalAlignment = newValue }
+  }
+  
+  /// Determine the transition behaviour of menu items while scrolling
+  /// the content. _Default: .scrollAlongside_
+  public var menuTransition: PagingMenuTransition {
+    get { return options.menuTransition }
+    set { options.menuTransition = newValue }
+  }
+  
+  /// Determine how users can interact with the menu items.
+  /// _Default: .scrolling_
+  public var menuInteraction: PagingMenuInteraction {
+    get { return options.menuInteraction }
+    set { options.menuInteraction = newValue }
+  }
+  
+  /// The class type for collection view layout. Override this if you
+  /// want to use your own subclass of the layout. Setting this
+  /// property will initialize the new layout type and update the
+  /// collection view.
+  /// _Default: PagingCollectionViewLayout.self_
+  public var menuLayoutClass: PagingCollectionViewLayout.Type {
+    get { return options.menuLayoutClass }
+    set { options.menuLayoutClass = newValue }
+  }
+  
+  /// Determine how the selected menu item should be aligned when it
+  /// is selected. Effectivly the same as the
+  /// `UICollectionViewScrollPosition`. _Default: .preferCentered_
+  public var selectedScrollPosition: PagingSelectedScrollPosition {
+    get { return options.selectedScrollPosition }
+    set { options.selectedScrollPosition = newValue }
+  }
+  
+  /// Add an indicator view to the selected menu item. The indicator
+  /// width will be equal to the selected menu items width. Insets
+  /// only apply horizontally. _Default: .visible_
+  public var indicatorOptions: PagingIndicatorOptions {
+    get { return options.indicatorOptions }
+    set { options.indicatorOptions = newValue }
+  }
+  
+  /// The class type for the indicator view. Override this if you want
+  /// your use your own subclass of PagingIndicatorView. _Default:
+  /// PagingIndicatorView.self_
+  public var indicatorClass: PagingIndicatorView.Type {
+    get { return options.indicatorClass }
+    set { options.indicatorClass = newValue }
+  }
+  
+  /// Determine the color of the indicator view.
+  public var indicatorColor: UIColor {
+    get { return options.indicatorColor }
+    set { options.indicatorColor = newValue }
+  }
+  
+  /// Add a border at the bottom of the menu items. The border will be
+  /// as wide as all the menu items. Insets only apply horizontally.
+  /// _Default: .visible_
+  public var borderOptions: PagingBorderOptions {
+    get { return options.borderOptions }
+    set { options.borderOptions = newValue }
+  }
+  
+  /// The class type for the border view. Override this if you want
+  /// your use your own subclass of PagingBorderView. _Default:
+  /// PagingBorderView.self_
+  public var borderClass: PagingBorderView.Type {
+    get { return options.borderClass }
+    set { options.borderClass = newValue }
+  }
+  
+  /// Determine the color of the border view.
+  public var borderColor: UIColor {
+    get { return options.borderColor }
+    set { options.borderColor = newValue }
+  }
+  
+  /// Updates the content inset for the menu items based on the
+  /// .safeAreaInsets property. _Default: true_
+  public var includeSafeAreaInsets: Bool {
+    get { return options.includeSafeAreaInsets }
+    set { options.includeSafeAreaInsets = newValue }
+  }
+  
+  /// The font used for title label on the menu items.
+  public var font: UIFont {
+     get { return options.font }
+     set { options.font = newValue }
+  }
+  
+  /// The font used for the currently selected menu item.
+  public var selectedFont: UIFont {
+     get { return options.selectedFont }
+     set { options.selectedFont = newValue }
+  }
+  
+  /// The color of the title label on the menu items.
+  public var textColor: UIColor {
+     get { return options.textColor }
+     set { options.textColor = newValue }
+  }
+  
+  /// The text color for the currently selected menu item.
+  public var selectedTextColor: UIColor {
+     get { return options.selectedTextColor }
+     set { options.selectedTextColor = newValue }
+  }
+  
+  /// The background color for the menu items.
+  open override var backgroundColor: UIColor? {
+    didSet {
+      if let backgroundColor = backgroundColor {
+        options.backgroundColor = backgroundColor
+      }
+    }
+  }
+  
+  /// The background color for the selected menu item.
+  public var selectedBackgroundColor: UIColor {
+     get { return options.selectedBackgroundColor }
+     set { options.selectedBackgroundColor = newValue }
+  }
+  
+  /// The background color for the view behind the menu items.
+  public var menuBackgroundColor: UIColor {
+     get { return options.menuBackgroundColor }
+     set { options.menuBackgroundColor = newValue }
+  }
+  
   public weak var delegate: PagingMenuDelegate? {
     didSet {
       pagingController.delegate = delegate
@@ -47,7 +204,7 @@ open class PagingMenuView: UIView {
   
   /// An instance that stores all the customization so that it's
   /// easier to share between other classes.
-  public var options = PagingOptions() {
+  public private(set) var options = PagingOptions() {
     didSet {
       if options.menuLayoutClass != oldValue.menuLayoutClass {
         let layout = createLayout(layout: options.menuLayoutClass.self)

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -19,6 +19,158 @@ open class PagingViewController:
 
   // MARK: Public Properties
   
+  /// The size for each of the menu items. _Default:
+  /// .sizeToFit(minWidth: 150, height: 40)_
+  public var menuItemSize: PagingMenuItemSize {
+    get { return options.menuItemSize }
+    set { options.menuItemSize = newValue }
+  }
+    
+  /// Determine the spacing between the menu items. _Default: 0_
+  public var menuItemSpacing: CGFloat {
+    get { return options.menuItemSpacing }
+    set { options.menuItemSpacing = newValue }
+  }
+  
+  /// Determine the insets at around all the menu items. _Default:
+  /// UIEdgeInsets.zero_
+  public var menuInsets: UIEdgeInsets {
+    get { return options.menuInsets }
+    set { options.menuInsets = newValue }
+  }
+  
+  /// Determine whether the menu items should be centered when all the
+  /// items can fit within the bounds of the view. _Default: .left_
+  public var menuHorizontalAlignment: PagingMenuHorizontalAlignment {
+    get { return options.menuHorizontalAlignment }
+    set { options.menuHorizontalAlignment = newValue }
+  }
+  
+  /// Determine the transition behaviour of menu items while scrolling
+  /// the content. _Default: .scrollAlongside_
+  public var menuTransition: PagingMenuTransition {
+    get { return options.menuTransition }
+    set { options.menuTransition = newValue }
+  }
+  
+  /// Determine how users can interact with the menu items.
+  /// _Default: .scrolling_
+  public var menuInteraction: PagingMenuInteraction {
+    get { return options.menuInteraction }
+    set { options.menuInteraction = newValue }
+  }
+  
+  /// The class type for collection view layout. Override this if you
+  /// want to use your own subclass of the layout. Setting this
+  /// property will initialize the new layout type and update the
+  /// collection view.
+  /// _Default: PagingCollectionViewLayout.self_
+  public var menuLayoutClass: PagingCollectionViewLayout.Type {
+    get { return options.menuLayoutClass }
+    set { options.menuLayoutClass = newValue }
+  }
+  
+  /// Determine how the selected menu item should be aligned when it
+  /// is selected. Effectivly the same as the
+  /// `UICollectionViewScrollPosition`. _Default: .preferCentered_
+  public var selectedScrollPosition: PagingSelectedScrollPosition {
+    get { return options.selectedScrollPosition }
+    set { options.selectedScrollPosition = newValue }
+  }
+  
+  /// Add an indicator view to the selected menu item. The indicator
+  /// width will be equal to the selected menu items width. Insets
+  /// only apply horizontally. _Default: .visible_
+  public var indicatorOptions: PagingIndicatorOptions {
+    get { return options.indicatorOptions }
+    set { options.indicatorOptions = newValue }
+  }
+  
+  /// The class type for the indicator view. Override this if you want
+  /// your use your own subclass of PagingIndicatorView. _Default:
+  /// PagingIndicatorView.self_
+  public var indicatorClass: PagingIndicatorView.Type {
+    get { return options.indicatorClass }
+    set { options.indicatorClass = newValue }
+  }
+  
+  /// Determine the color of the indicator view.
+  public var indicatorColor: UIColor {
+    get { return options.indicatorColor }
+    set { options.indicatorColor = newValue }
+  }
+  
+  /// Add a border at the bottom of the menu items. The border will be
+  /// as wide as all the menu items. Insets only apply horizontally.
+  /// _Default: .visible_
+  public var borderOptions: PagingBorderOptions {
+    get { return options.borderOptions }
+    set { options.borderOptions = newValue }
+  }
+  
+  /// The class type for the border view. Override this if you want
+  /// your use your own subclass of PagingBorderView. _Default:
+  /// PagingBorderView.self_
+  public var borderClass: PagingBorderView.Type {
+    get { return options.borderClass }
+    set { options.borderClass = newValue }
+  }
+  
+  /// Determine the color of the border view.
+  public var borderColor: UIColor {
+    get { return options.borderColor }
+    set { options.borderColor = newValue }
+  }
+  
+  /// Updates the content inset for the menu items based on the
+  /// .safeAreaInsets property. _Default: true_
+  public var includeSafeAreaInsets: Bool {
+    get { return options.includeSafeAreaInsets }
+    set { options.includeSafeAreaInsets = newValue }
+  }
+  
+  /// The font used for title label on the menu items.
+  public var font: UIFont {
+     get { return options.font }
+     set { options.font = newValue }
+  }
+  
+  /// The font used for the currently selected menu item.
+  public var selectedFont: UIFont {
+     get { return options.selectedFont }
+     set { options.selectedFont = newValue }
+  }
+  
+  /// The color of the title label on the menu items.
+  public var textColor: UIColor {
+     get { return options.textColor }
+     set { options.textColor = newValue }
+  }
+  
+  /// The text color for the currently selected menu item.
+  public var selectedTextColor: UIColor {
+     get { return options.selectedTextColor }
+     set { options.selectedTextColor = newValue }
+  }
+  
+  /// The background color for the menu items.
+  public var backgroundColor: UIColor {
+     get { return options.backgroundColor }
+     set { options.backgroundColor = newValue }
+  }
+  
+  /// The background color for the selected menu item.
+  public var selectedBackgroundColor: UIColor {
+     get { return options.selectedBackgroundColor }
+     set { options.selectedBackgroundColor = newValue }
+  }
+  
+  /// The background color for the view behind the menu items.
+  public var menuBackgroundColor: UIColor {
+     get { return options.menuBackgroundColor }
+     set { options.menuBackgroundColor = newValue }
+  }
+  
   /// Determine how users can interact with the page view controller.
   /// _Default: .scrolling_
   public var contentInteraction: PagingContentInteraction = .scrolling {
@@ -93,10 +245,10 @@ open class PagingViewController:
   /// called EMPageViewController which fixes a lot of the common
   /// issues with using UIPageViewController.
   public let pageViewController: EMPageViewController
-
+  
   /// An instance that stores all the customization so that it's
   /// easier to share between other classes.
-  public var options: PagingOptions {
+  public private(set) var options: PagingOptions {
     didSet {
       if options.menuLayoutClass != oldValue.menuLayoutClass {
         let layout = createLayout(layout: options.menuLayoutClass.self)

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -91,7 +91,7 @@ class PagingViewControllerSpec: QuickSpec {
           ]
           
           pagingViewController = PagingViewController()
-          pagingViewController.options.menuItemSize = .fixed(width: 100, height: 50)
+          pagingViewController.menuItemSize = .fixed(width: 100, height: 50)
           pagingViewController.dataSource = dataSource
           
           UIApplication.shared.keyWindow!.rootViewController = pagingViewController
@@ -160,7 +160,7 @@ class PagingViewControllerSpec: QuickSpec {
             ]
             
             pagingViewController = PagingViewController()
-            pagingViewController.options.menuItemSize = .fixed(width: 100, height: 50)
+            pagingViewController.menuItemSize = .fixed(width: 100, height: 50)
             pagingViewController.dataSource = dataSource
             
             UIApplication.shared.keyWindow!.rootViewController = pagingViewController
@@ -341,7 +341,7 @@ class PagingViewControllerSpec: QuickSpec {
         beforeEach {
           viewController = PagingViewController()
           viewController.register(PagingTitleCell.self, for: Item.self)
-          viewController.options.menuItemSize = .fixed(width: 100, height: 50)
+          viewController.menuItemSize = .fixed(width: 100, height: 50)
           viewController.infiniteDataSource = dataSource
           
           UIApplication.shared.keyWindow!.rootViewController = viewController

--- a/UnplashExample/ViewController.swift
+++ b/UnplashExample/ViewController.swift
@@ -145,20 +145,20 @@ class ViewController: UIViewController {
     super.viewDidLoad()
     
     pagingViewController.register(ImagePagingCell.self, for: ImageItem.self)
-    pagingViewController.options.menuItemSize = .fixed(width: menuItemSize.width, height: menuItemSize.height)
-    pagingViewController.options.menuItemSpacing = 8
-    pagingViewController.options.menuInsets = menuInsets
-    pagingViewController.options.borderColor = UIColor(white: 0, alpha: 0.1)
-    pagingViewController.options.indicatorColor = .black
+    pagingViewController.menuItemSize = .fixed(width: menuItemSize.width, height: menuItemSize.height)
+    pagingViewController.menuItemSpacing = 8
+    pagingViewController.menuInsets = menuInsets
+    pagingViewController.borderColor = UIColor(white: 0, alpha: 0.1)
+    pagingViewController.indicatorColor = .black
     
-    pagingViewController.options.indicatorOptions = .visible(
+    pagingViewController.indicatorOptions = .visible(
       height: 1,
       zIndex: Int.max,
       spacing: UIEdgeInsets.zero,
       insets: UIEdgeInsets.zero
     )
     
-    pagingViewController.options.borderOptions = .visible(
+    pagingViewController.borderOptions = .visible(
       height: 1,
       zIndex: Int.max - 1,
       insets: UIEdgeInsets(top: 0, left: 18, bottom: 0, right: 18)
@@ -195,7 +195,7 @@ class ViewController: UIViewController {
     menuView.menuHeightConstraint?.constant = height
     
     // Update the size of the menu items.
-    pagingViewController.options.menuItemSize = .fixed(
+    pagingViewController.menuItemSize = .fixed(
       width: menuItemSize.width,
       height: height - menuInsets.top - menuInsets.bottom
     )


### PR DESCRIPTION
This reverts the changes introduced in d93a1fe. It's not worth
introducing such a big breaking change just to remove a bit of
duplication internally in the framework.