### PR TITLE
Fix memory leak occurred when configuring size cache

### DIFF
--- a/Parchment/Classes/PagingController.swift
+++ b/Parchment/Classes/PagingController.swift
@@ -613,10 +613,10 @@ final class PagingController: NSObject {
   }
   
   private func configureSizeCache(for pagingItem: PagingItem) {
-    if let sizeDelegate = sizeDelegate {
+    if sizeDelegate != nil {
       sizeCache.implementsWidthDelegate = true
-      sizeCache.widthForPagingItem = { item, selected in
-        return sizeDelegate.width(for: item, isSelected: selected)
+      sizeCache.widthForPagingItem = { [weak self] item, selected in
+        return self?.sizeDelegate?.width(for: item, isSelected: selected)
       }
     }
   }


### PR DESCRIPTION
Closure capturing self even though there is no self inside the closure. Because if let variable getting self's reference and make the closure captures self. [weak self] solves the problem.