### PR TITLE
Reload before view controller and after view controller

### DIFF
--- a/Parchment/Classes/EMPageViewController.swift
+++ b/Parchment/Classes/EMPageViewController.swift
@@ -199,6 +199,10 @@ open class EMPageViewController: UIViewController, UIScrollViewDelegate {
     open func selectViewController(_ viewController: UIViewController, direction: EMPageViewControllerNavigationDirection, animated: Bool, completion: ((_ transitionSuccessful: Bool) -> Void)?) {
         
         if viewController == self.selectedViewController {
+            self.afterViewController = nil
+            self.loadAfterViewController(for: viewController)
+            self.beforeViewController = nil
+            self.loadBeforeViewController(for: viewController)
             return
         }
         


### PR DESCRIPTION
When I use `selectedViewController(:)`, I thought it is a way to reload data.
I have ever used `UIPageViewController`, which has the same behavior.
And it would be better than using `removeAllViewControllers()`.