### PR TITLE
Fix issue with initial selection being set

### DIFF
--- a/Parchment/Classes/PagingController.swift
+++ b/Parchment/Classes/PagingController.swift
@@ -64,33 +64,28 @@ final class PagingController: NSObject {
   }
   
   func select(pagingItem: PagingItem, animated: Bool) {
+    if collectionView.superview == nil || collectionView.window == nil {
+      state = .selected(pagingItem: pagingItem)
+      return
+    }
+    
     switch state {
     case .empty:
       state = .selected(pagingItem: pagingItem)
       
-      if collectionView.superview != nil {
-        if collectionView.window == nil {
-          delegate?.selectContent(
-            pagingItem: pagingItem,
-            direction: .none,
-            animated: false
-          )
-        } else {
-          reloadItems(around: pagingItem)
-          
-          delegate?.selectContent(
-            pagingItem: pagingItem,
-            direction: .none,
-            animated: false
-          )
-          
-          collectionView.selectItem(
-            at: visibleItems.indexPath(for: pagingItem),
-            animated: false,
-            scrollPosition: options.scrollPosition
-          )
-        }
-      }
+      reloadItems(around: pagingItem)
+      
+      delegate?.selectContent(
+        pagingItem: pagingItem,
+        direction: .none,
+        animated: false
+      )
+      
+      collectionView.selectItem(
+        at: visibleItems.indexPath(for: pagingItem),
+        animated: false,
+        scrollPosition: options.scrollPosition
+      )
       
     case .selected:
       if let currentPagingItem = state.currentPagingItem {
@@ -234,7 +229,8 @@ final class PagingController: NSObject {
   
   func viewAppeared() {
     switch state {
-    case let .selected(pagingItem), let .scrolling(pagingItem, _, _, _, _):
+    case let .selected(pagingItem), let .scrolling(_, pagingItem?, _, _, _):
+      state = .selected(pagingItem: pagingItem)
       reloadItems(around: pagingItem)
       
       delegate?.selectContent(

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -459,6 +459,7 @@ open class PagingViewController:
     pageViewController.didMove(toParentViewController: self)
     #endif
     
+    pageViewController.delegate = self
     pageViewController.dataSource = self
     configureContentInteraction()
 
@@ -476,12 +477,6 @@ open class PagingViewController:
     if didLayoutSubviews == false {
       didLayoutSubviews = true
       pagingController.viewAppeared()
-      
-      // Selecting a view controller in the page view triggers the
-      // delegate methods even if the view has not appeared yet. This
-      // causes problems with the initial state when we select items, so
-      // we wait until the view has appeared before setting the delegate.
-      pageViewController.delegate = self
     }
   }
   

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -94,11 +94,10 @@ class PagingViewControllerSpec: QuickSpec {
           pagingViewController.menuItemSize = .fixed(width: 100, height: 50)
           pagingViewController.dataSource = dataSource
           
-          UIApplication.shared.keyWindow!.rootViewController = pagingViewController
-          let _ = pagingViewController.view
-          
-          pagingViewController.collectionView.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
-          pagingViewController.viewDidLayoutSubviews()
+          let window = UIWindow(frame: UIScreen.main.bounds)
+          window.rootViewController = pagingViewController
+          window.makeKeyAndVisible()
+          pagingViewController.view.layoutIfNeeded()
         }
         
         it("reload the menu items") {
@@ -163,11 +162,10 @@ class PagingViewControllerSpec: QuickSpec {
             pagingViewController.menuItemSize = .fixed(width: 100, height: 50)
             pagingViewController.dataSource = dataSource
             
-            UIApplication.shared.keyWindow!.rootViewController = pagingViewController
-            let _ = pagingViewController.view
-            
-            pagingViewController.collectionView.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
-            pagingViewController.viewDidLayoutSubviews()
+            let window = UIWindow(frame: UIScreen.main.bounds)
+            window.rootViewController = pagingViewController
+            window.makeKeyAndVisible()
+            pagingViewController.view.layoutIfNeeded()
           }
           
           it("reloads data around item") {
@@ -292,10 +290,10 @@ class PagingViewControllerSpec: QuickSpec {
             pagingViewController = PagingViewController()
             pagingViewController.dataSource = dataSource
             
-            UIApplication.shared.keyWindow!.rootViewController = pagingViewController
-            let _ = pagingViewController.view
-            pagingViewController.collectionView.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
-            pagingViewController.viewDidLayoutSubviews()
+            let window = UIWindow(frame: UIScreen.main.bounds)
+            window.rootViewController = pagingViewController
+            window.makeKeyAndVisible()
+            pagingViewController.view.layoutIfNeeded()
           }
           
           describe("width delegate") {
@@ -344,11 +342,10 @@ class PagingViewControllerSpec: QuickSpec {
           viewController.menuItemSize = .fixed(width: 100, height: 50)
           viewController.infiniteDataSource = dataSource
           
-          UIApplication.shared.keyWindow!.rootViewController = viewController
-          let _ = viewController.view
-          
-          viewController.collectionView.bounds = CGRect(x: 0, y: 0, width: 1000, height: 50)
-          viewController.viewDidLayoutSubviews()
+          let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 1000, height: 50))
+          window.rootViewController = viewController
+          window.makeKeyAndVisible()
+          viewController.view.layoutIfNeeded()
         }
         
         it("selecting the first item generates enough items") {
@@ -368,11 +365,36 @@ class PagingViewControllerSpec: QuickSpec {
           let items = viewController.collectionView.numberOfItems(inSection: 0)
           expect(items).to(equal(21))
         }
-        
       }
       
+      describe("selecting index before initial render") {
+        it("starts at the selected item") {
+          let viewController0 = UIViewController()
+          let viewController1 = UIViewController()
+          let item0 = PagingIndexItem(index: 0, title: "0")
+          let item1 = PagingIndexItem(index: 1, title: "1")
+
+          let dataSource = ReloadingDataSource()
+          dataSource.viewControllers = [viewController0, viewController1]
+          dataSource.items = [item0, item1]
+
+          let pagingViewController = PagingViewController()
+          pagingViewController.dataSource = dataSource
+          pagingViewController.select(index: 1)
+
+          let window = UIWindow(frame: UIScreen.main.bounds)
+          window.rootViewController = pagingViewController
+          window.makeKeyAndVisible()
+          pagingViewController.view.layoutIfNeeded()
+          
+          expect(pagingViewController.pageViewController.selectedViewController).to(equal(viewController1))
+          expect(pagingViewController.collectionView.indexPathsForSelectedItems).to(equal([IndexPath(item: 1, section: 0)]))
+          expect(pagingViewController.state).to(equal(PagingState.selected(pagingItem: item1)))
+        }
+      }
+
       describe("retain cycles") {
-        
+
         it("deinits PagingViewController") {
           var instance: DeinitPagingViewController? = DeinitPagingViewController()
           waitUntil { done in
@@ -384,7 +406,7 @@ class PagingViewControllerSpec: QuickSpec {
             }
           }
         }
-        
+
       }
     }
   }


### PR DESCRIPTION
When selecting an index before the view has appeared the selected item
isn't updated. This was introduced after the refactoring in
15a8ba9. Fixed by always waiting until the view has appeared before we
select the initial item.

Fixes #428 #435 #437 