### PR TITLE
Revert changes to page view controller delegate

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -459,7 +459,6 @@ open class PagingViewController:
     pageViewController.didMove(toParentViewController: self)
     #endif
     
-    pageViewController.delegate = self
     pageViewController.dataSource = self
     configureContentInteraction()
 
@@ -477,6 +476,12 @@ open class PagingViewController:
     if didLayoutSubviews == false {
       didLayoutSubviews = true
       pagingController.viewAppeared()
+      
+      // Selecting a view controller in the page view triggers the
+      // delegate methods even if the view has not appeared yet. This
+      // causes problems with the initial state when we select items, so
+      // we wait until the view has appeared before setting the delegate.
+      pageViewController.delegate = self
     }
   }
   

--- a/ParchmentTests/PagingViewControllerSpec.swift
+++ b/ParchmentTests/PagingViewControllerSpec.swift
@@ -392,6 +392,35 @@ class PagingViewControllerSpec: QuickSpec {
           expect(pagingViewController.state).to(equal(PagingState.selected(pagingItem: item1)))
         }
       }
+      
+      describe("reloading data before initial render") {
+        it("starts at the selected item") {
+          let viewController0 = UIViewController()
+          let viewController1 = UIViewController()
+          let viewController2 = UIViewController()
+          let item0 = PagingIndexItem(index: 0, title: "0")
+          let item1 = PagingIndexItem(index: 1, title: "1")
+          let item2 = PagingIndexItem(index: 2, title: "2")
+
+          let dataSource = ReloadingDataSource()
+          dataSource.viewControllers = [viewController0, viewController1, viewController2]
+          dataSource.items = [item0, item1, item2]
+          
+          let pagingViewController = PagingViewController()
+          pagingViewController.dataSource = dataSource
+          pagingViewController.reloadData()
+          pagingViewController.select(index: 1)
+          
+          let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 1000, height: 50))
+          window.rootViewController = pagingViewController
+          window.makeKeyAndVisible()
+          pagingViewController.view.layoutIfNeeded()
+          
+          expect(pagingViewController.pageViewController.selectedViewController).to(equal(viewController1))
+          expect(pagingViewController.collectionView.indexPathsForSelectedItems).to(equal([IndexPath(item: 1, section: 0)]))
+          expect(pagingViewController.state).to(equal(PagingState.selected(pagingItem: item1)))
+        }
+      }
 
       describe("retain cycles") {
 


### PR DESCRIPTION
When fixing the issue initial selections in cb3dea5 the
EMPageViewController delegate setup was moved back into viewDidLoad as
it seemed to work. This is still needed as it fixes another issue when
calling reloadData before the view has appeared.