### PR TITLE
Fix regression causing indicator not to animate

### DIFF
--- a/Parchment/Classes/PagingController.swift
+++ b/Parchment/Classes/PagingController.swift
@@ -409,29 +409,28 @@ final class PagingController: NSObject {
     )
     
     if options.menuTransition == .scrollAlongside {
-      if collectionView.contentSize.width >= collectionView.bounds.width && state.progress != 0 {
-        let contentOffset = CGPoint(
-          x: initialContentOffset.x + (distance * abs(progress)),
-          y: initialContentOffset.y
-        )
-        
-        let invalidationContext = PagingInvalidationContext()
-        
-        // We don't want to update the content offset if there is no
-        // upcoming item to scroll to. We still need to invalidate the
-        // layout in order to update the layout attributes for the
-        // decoration views. We need to use setContentOffset with no
-        // animation in order to stop any ongoing scroll.
-        if upcomingPagingItem != nil {
+      let invalidationContext = PagingInvalidationContext()
+      
+      // We don't want to update the content offset if there is no
+      // upcoming item to scroll to. We still need to invalidate the
+      // layout in order to update the layout attributes for the
+      // decoration views. We need to use setContentOffset with no
+      // animation in order to stop any ongoing scroll.
+      if upcomingPagingItem != nil {
+        if collectionView.contentSize.width >= collectionView.bounds.width && state.progress != 0 {
+          let contentOffset = CGPoint(
+            x: initialContentOffset.x + (distance * abs(progress)),
+            y: initialContentOffset.y
+          )
           collectionView.setContentOffset(contentOffset, animated: false)
-          
-          if sizeCache.implementsWidthDelegate {
-            invalidationContext.invalidateSizes = true
-          }
         }
         
-        collectionViewLayout.invalidateLayout(with: invalidationContext)
+        if sizeCache.implementsWidthDelegate {
+          invalidationContext.invalidateSizes = true
+        }
       }
+      
+      collectionViewLayout.invalidateLayout(with: invalidationContext)
     }
   }
   


### PR DESCRIPTION
When the width of the menu items are less than the bounds width the
indicator does not animate while scrolling. This issue was introduced
in the 2.0 refactor. Fixed by ensuring we invalidate the collection
view layout regardless of the menu item size (it even says we need
this in the comments, but it was messed up during the refactor).