### PR TITLE
Fix issues with header example

### DIFF
--- a/Example/Resources/TableViewController.swift
+++ b/Example/Resources/TableViewController.swift
@@ -15,7 +15,7 @@ class TableViewController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: TableViewController.CellIdentifier, for: indexPath)
-        cell.textLabel?.text = "Title"
+        cell.textLabel?.text = "Title \(indexPath.row)"
         return cell
     }
     


### PR DESCRIPTION
When swiping between pages the header constraint was sometimes reset
causing an ugly jump. This also improves the scrollIndicatorInsets by
updating them while scrolling move alongside the table view.