### PR TITLE
Update menu constraints when menuItemSize changes

### DIFF
--- a/Parchment/Classes/PagingController.swift
+++ b/Parchment/Classes/PagingController.swift
@@ -320,6 +320,7 @@ final class PagingController: NSObject {
     }
     
     sizeCache.options = options
+    collectionViewLayout.invalidateLayout()
   }
   
   private func configureCollectionViewLayout() {

--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -9,9 +9,21 @@ import UIKit
 /// `loadView:` in `PagingViewController` to use your subclass.
 open class PagingView: UIView {
   
-  public let options: PagingOptions
+  // MARK: Public Properties
+  
   public let collectionView: UICollectionView
   public let pageView: UIView
+  public var options: PagingOptions {
+    didSet {
+      heightConstraint?.constant = options.menuItemSize.height
+    }
+  }
+  
+  // MARK: Private Properties
+  
+  private var heightConstraint: NSLayoutConstraint?
+  
+  // MARK: Initializers
   
   /// Creates an instance of `PagingView`.
   ///
@@ -27,6 +39,8 @@ open class PagingView: UIView {
   required public init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+  
+  // MARK: Public Methods
   
   /// Configures the view hierarchy, sets up the layout constraints
   /// and does any other customization based on the `PagingOptions`.
@@ -71,8 +85,10 @@ open class PagingView: UIView {
     
     let verticalConstraintsFormat: String
     switch options.menuPosition {
-    case .top:          verticalConstraintsFormat = "V:|[collectionView(==height)][pageView]|"
-    case .bottom:       verticalConstraintsFormat = "V:|[pageView][collectionView(==height)]|"
+    case .top:
+      verticalConstraintsFormat = "V:|[collectionView(==height)][pageView]|"
+    case .bottom:
+      verticalConstraintsFormat = "V:|[pageView][collectionView(==height)]|"
     }
 
     let verticalContraints = NSLayoutConstraint.constraints(
@@ -84,6 +100,12 @@ open class PagingView: UIView {
     addConstraints(horizontalCollectionViewContraints)
     addConstraints(horizontalPagingContentViewContraints)
     addConstraints(verticalContraints)
+    
+    for constraint in verticalContraints {
+      if constraint.firstAttribute == NSLayoutConstraint.Attribute.height {
+        heightConstraint = constraint
+      }
+    }
   }
   
 }

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -268,6 +268,7 @@ open class PagingViewController:
       }
       
       pagingController.options = options
+      pagingView.options = options
     }
   }
   


### PR DESCRIPTION
This allows you to update the menu height after the initial render,
for instance if you want to hide/show the menu based on the number of
pages that are being display.