### PR TITLE
Add delegate method when selecting item /w @yosshi4486

### DIFF
--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -595,6 +595,8 @@ open class PagingViewController:
   // MARK: UICollectionViewDelegate
   
   open func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    let pagingItem = pagingController.visibleItems.pagingItem(for: indexPath)
+    delegate?.pagingViewController(self, didSelectItem: pagingItem)
     pagingController.select(indexPath: indexPath, animated: true)
   }
   

--- a/Parchment/Protocols/PagingViewControllerDelegate.swift
+++ b/Parchment/Protocols/PagingViewControllerDelegate.swift
@@ -51,6 +51,14 @@ public protocol PagingViewControllerDelegate: class {
     startingViewController: UIViewController?,
     destinationViewController: UIViewController,
     transitionSuccessful: Bool)
+  
+  /// Called when paging cell is selected in the menu.
+  ///
+  /// - Parameter pagingViewController: The `PagingViewController` instance
+  /// - Parameter pagingItem: The item that was selected.
+  func pagingViewController(
+    _ pagingViewController: PagingViewController,
+    didSelectItem pagingItem: PagingItem)
 }
 
 public extension PagingViewControllerDelegate {
@@ -79,6 +87,12 @@ public extension PagingViewControllerDelegate {
     startingViewController: UIViewController?,
     destinationViewController: UIViewController,
     transitionSuccessful: Bool) {
+    return
+  }
+  
+  func pagingViewController(
+    _ pagingViewController: PagingViewController,
+    didSelectItem pagingItem: PagingItem) {
     return
   }
 }


### PR DESCRIPTION
Adds a new delegate method called didSelectItem that is called when
the user selects an item in the menu. This is different from the
existing didScrollToItem delegate method, as this will be called even
if you are already on that page. This method will be called before the
collection view starts scrolling to the new item.