### PR TITLE
Add support for self-sizing cells

### DIFF
--- a/Example/Examples/MultipleCells/MultipleCellsViewController.swift
+++ b/Example/Examples/MultipleCells/MultipleCellsViewController.swift
@@ -15,10 +15,9 @@ class MultipleCellsViewController: UIViewController {
         super.viewDidLoad()
         
         let pagingViewController = PagingViewController()
-        pagingViewController.sizeDelegate = self
         pagingViewController.register(IconPagingCell.self, for: IconItem.self)
         pagingViewController.register(PagingTitleCell.self, for: PagingIndexItem.self)
-        pagingViewController.menuItemSize = .fixed(width: 60, height: 60)
+        pagingViewController.menuItemSize = .selfSizing(estimatedWidth: 100, height: 60)
         pagingViewController.dataSource = self
         pagingViewController.select(index: 0)
         
@@ -47,32 +46,6 @@ extension MultipleCellsViewController: PagingViewControllerDataSource {
   
   func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
     return items.count
-  }
-  
-}
-
-extension MultipleCellsViewController: PagingViewControllerSizeDelegate {
-  
-  // We want the size of our paging items to equal the width of the
-  // city title. Parchment does not support self-sizing cells at
-  // the moment, so we have to handle the calculation ourself. We
-  // can access the title string by casting the paging item to a
-  // PagingTitleItem, which is the PagingItem type used by
-  // FixedPagingViewController.
-  func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat {
-    guard let item = pagingItem as? PagingIndexItem else { return 50 }
-    
-    let insets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
-    let size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: pagingViewController.options.menuItemSize.height)
-    let attributes = [NSAttributedString.Key.font: pagingViewController.options.font]
-    
-    let rect = item.title.boundingRect(with: size,
-                                       options: .usesLineFragmentOrigin,
-                                       attributes: attributes,
-                                       context: nil)
-    
-    let width = ceil(rect.width) + insets.left + insets.right
-    return width
   }
   
 }

--- a/Example/Examples/SelfSizing/SelfSizingViewController.swift
+++ b/Example/Examples/SelfSizing/SelfSizingViewController.swift
@@ -1,0 +1,39 @@
+import UIKit
+import Parchment
+
+final class SelfSizingViewController: PagingViewController {
+  private let movies = [
+    "Pulp Fiction",
+    "The Shawshank Redemption",
+    "The Dark Knight",
+    "Fight Club",
+    "Se7en",
+    "Saving Private Ryan",
+    "Interstellar",
+    "Harakiri",
+    "Psycho",
+    "The Intouchables",
+    "Once Upon a Time in the West",
+    "Alien"
+  ]
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    dataSource = self
+    menuItemSize = .selfSizing(estimatedWidth: 100, height: 40)
+  }
+}
+
+extension SelfSizingViewController: PagingViewControllerDataSource {
+  func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+    return PagingIndexItem(index: index, title: movies[index])
+  }
+  
+  func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
+    return ContentViewController(title: movies[index])
+  }
+  
+  func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
+    return movies.count
+  }
+}

--- a/Example/ExamplesViewController.swift
+++ b/Example/ExamplesViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 enum Example: CaseIterable {
   case basic
+  case selfSizing
   case calendar
   case sizeDelegate
   case images
@@ -17,6 +18,8 @@ enum Example: CaseIterable {
     switch self {
     case .basic:
       return "Basic"
+    case .selfSizing:
+      return "Self sizing cells"
     case .calendar:
       return "Calendar"
     case .sizeDelegate:
@@ -95,6 +98,8 @@ final class ExamplesViewController: UITableViewController {
       return BasicViewController(nibName: nil, bundle: nil)
     case .calendar:
       return CalendarViewController(nibName: nil, bundle: nil)
+    case .selfSizing:
+      return SelfSizingViewController()
     case .sizeDelegate:
       return SizeDelegateViewController(nibName: nil, bundle: nil)
     case .images:

--- a/Example/Resources/ContentViewController.swift
+++ b/Example/Resources/ContentViewController.swift
@@ -16,11 +16,12 @@ final class ContentViewController: UIViewController {
     let label = UILabel(frame: .zero)
     label.font = UIFont.systemFont(ofSize: 50, weight: UIFont.Weight.thin)
     label.textColor = UIColor(red: 95/255, green: 102/255, blue: 108/255, alpha: 1)
+    label.textAlignment = .center
     label.text = content
     label.sizeToFit()
     
     view.addSubview(label)
-    view.constrainCentered(label)
+    view.constrainToEdges(label)
     view.backgroundColor = .white
   }
   

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		3EFEFBF71C80B8820023C949 /* PagingIndicatorLayoutAttributesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesTests.swift */; };
 		951E163720A21D3A0055E9D4 /* PagingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842601F4251F90072038C /* PagingViewControllerTests.swift */; };
 		952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952D802E1E37CC09003DCB18 /* PagingTransition.swift */; };
+		953B8D352416C3DC0047BBA1 /* SelfSizingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953B8D342416C3DC0047BBA1 /* SelfSizingViewController.swift */; };
 		954842591F42438E0072038C /* PagingInvalidationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842581F42438E0072038C /* PagingInvalidationContext.swift */; };
 		9548425D1F42486B0072038C /* PagingDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9548425C1F42486B0072038C /* PagingDiff.swift */; };
 		954842631F4252070072038C /* PagingDiffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842621F4252070072038C /* PagingDiffTests.swift */; };
@@ -197,6 +198,7 @@
 		3EC0184C1C95F993005421AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Resources/Info.plist; sourceTree = "<group>"; };
 		3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingIndicatorLayoutAttributesTests.swift; sourceTree = "<group>"; };
 		952D802E1E37CC09003DCB18 /* PagingTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingTransition.swift; sourceTree = "<group>"; };
+		953B8D342416C3DC0047BBA1 /* SelfSizingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSizingViewController.swift; sourceTree = "<group>"; };
 		954842581F42438E0072038C /* PagingInvalidationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingInvalidationContext.swift; sourceTree = "<group>"; };
 		9548425C1F42486B0072038C /* PagingDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDiff.swift; sourceTree = "<group>"; };
 		954842601F4251F90072038C /* PagingViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingViewControllerTests.swift; sourceTree = "<group>"; };
@@ -440,6 +442,14 @@
 			path = Protocols;
 			sourceTree = "<group>";
 		};
+		953B8D332416C3C60047BBA1 /* SelfSizing */ = {
+			isa = PBXGroup;
+			children = (
+				953B8D342416C3DC0047BBA1 /* SelfSizingViewController.swift */,
+			);
+			path = SelfSizing;
+			sourceTree = "<group>";
+		};
 		955453CA2413DBCE00923BC8 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -460,6 +470,7 @@
 			children = (
 				955453CC2413DBEB00923BC8 /* Basic */,
 				955453CD2413DC5A00923BC8 /* Calendar */,
+				953B8D332416C3C60047BBA1 /* SelfSizing */,
 				955453D42413DD7A00923BC8 /* SizeDelegate */,
 				955453D72413E0FA00923BC8 /* Images */,
 				955453DC2413E1A500923BC8 /* Icons */,
@@ -861,6 +872,7 @@
 				955453D82413E11300923BC8 /* UnsplashViewController.swift in Sources */,
 				955453EF2415172800923BC8 /* MultipleCellsViewController.swift in Sources */,
 				955453DF2413E1B200923BC8 /* IconViewController.swift in Sources */,
+				953B8D352416C3DC0047BBA1 /* SelfSizingViewController.swift in Sources */,
 				955453D62413DD8E00923BC8 /* SizeDelegateViewController.swift in Sources */,
 				955453D92413E11300923BC8 /* ImageCollectionViewCell.swift in Sources */,
 				955453EA241515D900923BC8 /* ScrollViewController.swift in Sources */,

--- a/Parchment/Classes/PagingCell.swift
+++ b/Parchment/Classes/PagingCell.swift
@@ -4,11 +4,6 @@ import UIKit
 /// items. When creating your own custom cells, you need to subclass
 /// this type instead of `UICollectionViewCell` directly.
 open class PagingCell: UICollectionViewCell {
-  
-  open override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
-    return layoutAttributes
-  }
-  
   /// Called by the `PagingViewControllerDataSource` to customize the
   /// cell with an instance conforming to `PagingItem`. You have to
   /// override this method when creating your own subclass – the
@@ -23,5 +18,4 @@ open class PagingCell: UICollectionViewCell {
   open func setPagingItem(_ pagingItem: PagingItem, selected: Bool, options: PagingOptions) {
     fatalError("setPagingItem: not implemented")
   }
-  
 }

--- a/Parchment/Classes/PagingOptions.swift
+++ b/Parchment/Classes/PagingOptions.swift
@@ -126,6 +126,8 @@ public struct PagingOptions {
       return width
     case let .sizeToFit(minWidth, _):
       return minWidth
+    case let .selfSizing(estimatedItemWidth, _):
+      return estimatedItemWidth
     }
   }
   

--- a/Parchment/Classes/PagingTitleCell.swift
+++ b/Parchment/Classes/PagingTitleCell.swift
@@ -40,11 +40,22 @@ open class PagingTitleCell: PagingCell {
   open func configure() {
     contentView.addSubview(titleLabel)
     contentView.isAccessibilityElement = true
-  }
-  
-  open override func layoutSubviews() {
-    super.layoutSubviews()
-    titleLabel.frame = contentView.bounds
+    titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    
+    let horizontalConstraints = NSLayoutConstraint.constraints(
+      withVisualFormat: "H:|-20-[label]-20-|",
+      options: NSLayoutConstraint.FormatOptions(),
+      metrics: nil,
+      views: ["label": titleLabel])
+    
+    let verticalContraints = NSLayoutConstraint.constraints(
+      withVisualFormat: "V:|[label]|",
+      options: NSLayoutConstraint.FormatOptions(),
+      metrics: nil,
+      views: ["label": titleLabel])
+    
+    contentView.addConstraints(horizontalConstraints)
+    contentView.addConstraints(verticalContraints)
   }
   
   open func configureTitleLabel() {

--- a/Parchment/Enums/PagingMenuItemSize.swift
+++ b/Parchment/Enums/PagingMenuItemSize.swift
@@ -4,6 +4,11 @@ import UIKit
 public enum PagingMenuItemSize {
   case fixed(width: CGFloat, height: CGFloat)
   
+  // Automatically calculate the size of the menu items based on the
+  // cells intrinsic content size. Try to come up with an estimated
+  // width that's similar to the expected width of the cells.
+  case selfSizing(estimatedWidth: CGFloat, height: CGFloat)
+  
   // Tries to fit all menu items inside the bounds of the screen.
   // If the items can't fit, the items will scroll as normal and
   // set the menu items width to `minWidth`.
@@ -16,6 +21,7 @@ public extension PagingMenuItemSize {
     switch self {
     case let .fixed(width, _): return width
     case let .sizeToFit(minWidth, _): return minWidth
+    case let .selfSizing(estimatedWidth, _): return estimatedWidth
     }
   }
   
@@ -23,6 +29,7 @@ public extension PagingMenuItemSize {
     switch self {
     case let .fixed(_, height): return height
     case let .sizeToFit(_, height): return height
+    case let .selfSizing(_, height): return height
     }
   }
   

--- a/README.md
+++ b/README.md
@@ -276,6 +276,11 @@ The size of the menu items. When using [`sizeDelegate`](#size-delegate) the widt
 enum PagingMenuItemSize {
   case fixed(width: CGFloat, height: CGFloat)
 
+  // Automatically calculate the size of the menu items based on the
+  // cells intrinsic content size. Try to come up with an estimated
+  // width that's similar to the expected width of the cells.
+  case selfSizing(estimatedWidth: CGFloat, height: CGFloat)
+
   // Tries to fit all menu items inside the bounds of the screen.
   // If the items can't fit, the items will scroll as normal and
   // set the menu items width to `minWidth`.


### PR DESCRIPTION
Adds another menuItemSize option called .selfSizing that will
automatically calculate the size based on the cells constraints.

Usage:

```Swift
let pagingViewController = PagingViewController()
pagingViewController.menuItemSize = .selfSizing(estimatedWidth: 100, height: 40)
```