### PR TITLE
Fix menu title padding issue when using size delegate

### DIFF
--- a/Example/Examples/SizeDelegate/SizeDelegateViewController.swift
+++ b/Example/Examples/SizeDelegate/SizeDelegateViewController.swift
@@ -29,6 +29,7 @@ final class SizeDelegateViewController: UIViewController {
     let pagingViewController = PagingViewController()
     pagingViewController.dataSource = self
     pagingViewController.sizeDelegate = self
+    pagingViewController.menuItemSpacing = 10
     
     // Add the paging view controller as a child view controller and
     // contrain it to all edges.
@@ -67,7 +68,7 @@ extension SizeDelegateViewController: PagingViewControllerSizeDelegate {
   func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat {
     guard let item = pagingItem as? PagingIndexItem else { return 0 }
     
-    let insets = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
+    let insets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     let size = CGSize(width: CGFloat.greatestFiniteMagnitude, height: pagingViewController.options.menuItemSize.height)
     let attributes = [NSAttributedString.Key.font: pagingViewController.options.font]
     

--- a/Parchment/Classes/PagingTitleCell.swift
+++ b/Parchment/Classes/PagingTitleCell.swift
@@ -9,6 +9,8 @@ open class PagingTitleCell: PagingCell {
   
   public let titleLabel = UILabel(frame: .zero)
   private var viewModel: PagingTitleCellViewModel?
+
+  private var labelHorizontalConstraints: [NSLayoutConstraint]?
   
   open override var isSelected: Bool {
     didSet {
@@ -41,12 +43,14 @@ open class PagingTitleCell: PagingCell {
     contentView.addSubview(titleLabel)
     contentView.isAccessibilityElement = true
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
-    
+
     let horizontalConstraints = NSLayoutConstraint.constraints(
-      withVisualFormat: "H:|-20-[label]-20-|",
+      withVisualFormat: "H:|[label]|",
       options: NSLayoutConstraint.FormatOptions(),
       metrics: nil,
       views: ["label": titleLabel])
+    
+    labelHorizontalConstraints = horizontalConstraints
     
     let verticalContraints = NSLayoutConstraint.constraints(
       withVisualFormat: "V:|[label]|",
@@ -71,6 +75,10 @@ open class PagingTitleCell: PagingCell {
       titleLabel.font = viewModel.font
       titleLabel.textColor = viewModel.textColor
       backgroundColor = viewModel.backgroundColor
+    }
+
+    if case .selfSizing = viewModel.menuItemSize {
+      labelHorizontalConstraints?.forEach { $0.constant = 20 }
     }
   }
 

--- a/Parchment/Structs/PagingCellViewModel.swift
+++ b/Parchment/Structs/PagingCellViewModel.swift
@@ -10,6 +10,7 @@ struct PagingTitleCellViewModel {
   let backgroundColor: UIColor
   let selectedBackgroundColor: UIColor
   let selected: Bool
+  let menuItemSize: PagingMenuItemSize
   
   init(title: String?, selected: Bool, options: PagingOptions) {
     self.title = title
@@ -20,6 +21,7 @@ struct PagingTitleCellViewModel {
     self.backgroundColor = options.backgroundColor
     self.selectedBackgroundColor = options.selectedBackgroundColor
     self.selected = selected
+    self.menuItemSize = options.menuItemSize
   }
   
 }


### PR DESCRIPTION
### Issue ###
In SizeDelegateViewController example, if insets are zero, then the menu label will be cut down and not display the whole text.

The label inside PagingTitleCell has default horizontal padding set to 20, which will cause the label width to become smaller than it should be when the size delegate was implemented.

### What changed ###
The default horizontal padding for the label is zero. Set additional padding when using self sizing type.