### PR TITLE
Fix regression causing menuInteraction property not to work properly

### DIFF
--- a/Parchment/Classes/PagingController.swift
+++ b/Parchment/Classes/PagingController.swift
@@ -330,8 +330,6 @@ final class PagingController: NSObject {
   }
   
   private func configureCollectionView() {
-    collectionView.isScrollEnabled = false
-    collectionView.alwaysBounceHorizontal = false
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.dataSource = self
     
@@ -350,6 +348,9 @@ final class PagingController: NSObject {
     if let swipeGestureRecognizerRight = swipeGestureRecognizerRight {
       collectionView.removeGestureRecognizer(swipeGestureRecognizerRight)
     }
+    
+    collectionView.isScrollEnabled = false
+    collectionView.alwaysBounceHorizontal = false
     
     switch (options.menuInteraction) {
     case .scrolling:
@@ -394,7 +395,7 @@ final class PagingController: NSObject {
     }
     
     if let pagingItem = upcomingPagingItem {
-      select(pagingItem: pagingItem, animated: false)
+      select(pagingItem: pagingItem, animated: true)
     }
   }
   


### PR DESCRIPTION
Close #485

The behavior of `menuInteraction = .swipe    // or .none` requires `collectionView.isScrollEnabled = false`.

But the `menuInteraction` changes call the `configureMenuInteraction()` directly and  pass through the `collectionView.isScrollEnabled = false` setting.

https://github.com/rechsteiner/Parchment/blob/e0dc31a29823d62e345a9890c749c96313ff3812/Parchment/Classes/PagingViewController.swift#L69-L74
https://github.com/rechsteiner/Parchment/blob/e0dc31a29823d62e345a9890c749c96313ff3812/Parchment/Classes/PagingController.swift#L25-L29
https://github.com/rechsteiner/Parchment/blob/e0dc31a29823d62e345a9890c749c96313ff3812/Parchment/Classes/PagingController.swift#L317-L320
https://github.com/rechsteiner/Parchment/blob/e0dc31a29823d62e345a9890c749c96313ff3812/Parchment/Classes/PagingController.swift#L332-L363

I move the collectionView's setting codes and add a swipe animation based on ver1.7.0 implements.

https://github.com/rechsteiner/Parchment/blob/952db5d6608d1c7eac1d68b5e72fccf56186f625/Parchment/Classes/PagingViewController.swift#L624-L645

https://github.com/rechsteiner/Parchment/blob/952db5d6608d1c7eac1d68b5e72fccf56186f625/Parchment/Classes/PagingViewController.swift#L683
