### PR TITLE
Add support calculating vertical distances

### DIFF
--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -81,6 +81,9 @@
 		95591F21222C3A0400677B4B /* PagingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95591F20222C3A0400677B4B /* PagingControllerTests.swift */; };
 		95591F23222C522800677B4B /* PagingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95591F22222C522800677B4B /* PagingController.swift */; };
 		9568922B222C525C00AFF250 /* CollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9568922A222C525C00AFF250 /* CollectionView.swift */; };
+		9575BEB32461FEF9002403F6 /* CreateDistance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9575BEB22461FEF9002403F6 /* CreateDistance.swift */; };
+		9575BEB52462034B002403F6 /* PagingDistanceRightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9575BEB42462034B002403F6 /* PagingDistanceRightTests.swift */; };
+		9575BEB72463490B002403F6 /* PagingDistanceCenteredTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9575BEB62463490B002403F6 /* PagingDistanceCenteredTests.swift */; };
 		957F14091E35583500E562F8 /* PagingCellLayoutAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */; };
 		95868C2C2003DA87004B392B /* PagingContentInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95868C2B2003DA87004B392B /* PagingContentInteraction.swift */; };
 		95868C32200412D8004B392B /* InvalidationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95868C31200412D8004B392B /* InvalidationState.swift */; };
@@ -90,6 +93,7 @@
 		95A52A151FF81F70002A2ED4 /* PagingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A52A141FF81F70002A2ED4 /* PagingLayout.swift */; };
 		95A84B0520E586FA0031520F /* PagingStaticDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A84B0420E586FA0031520F /* PagingStaticDataSource.swift */; };
 		95A84B0D20ED46920031520F /* AnyPagingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95A84B0C20ED46920031520F /* AnyPagingItem.swift */; };
+		95AD07EB2438F71A002F1D12 /* PagingDistanceLeftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95AD07EA2438F71A002F1D12 /* PagingDistanceLeftTests.swift */; };
 		95B301171E59FCD500B95D02 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95B301161E59FCD500B95D02 /* UIEdgeInsets.swift */; };
 		95D2AE36242BB22F00AC3D46 /* PageViewDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D2AE35242BB22F00AC3D46 /* PageViewDirection.swift */; };
 		95D2AE38242BB24800AC3D46 /* PageViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95D2AE37242BB24800AC3D46 /* PageViewState.swift */; };
@@ -266,6 +270,9 @@
 		95591F20222C3A0400677B4B /* PagingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingControllerTests.swift; sourceTree = "<group>"; };
 		95591F22222C522800677B4B /* PagingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingController.swift; sourceTree = "<group>"; };
 		9568922A222C525C00AFF250 /* CollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
+		9575BEB22461FEF9002403F6 /* CreateDistance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDistance.swift; sourceTree = "<group>"; };
+		9575BEB42462034B002403F6 /* PagingDistanceRightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDistanceRightTests.swift; sourceTree = "<group>"; };
+		9575BEB62463490B002403F6 /* PagingDistanceCenteredTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDistanceCenteredTests.swift; sourceTree = "<group>"; };
 		957F14081E35583500E562F8 /* PagingCellLayoutAttributes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingCellLayoutAttributes.swift; sourceTree = "<group>"; };
 		95868C2B2003DA87004B392B /* PagingContentInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingContentInteraction.swift; sourceTree = "<group>"; };
 		95868C31200412D8004B392B /* InvalidationState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvalidationState.swift; sourceTree = "<group>"; };
@@ -278,6 +285,7 @@
 		95A52A141FF81F70002A2ED4 /* PagingLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingLayout.swift; sourceTree = "<group>"; };
 		95A84B0420E586FA0031520F /* PagingStaticDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingStaticDataSource.swift; sourceTree = "<group>"; };
 		95A84B0C20ED46920031520F /* AnyPagingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyPagingItem.swift; sourceTree = "<group>"; };
+		95AD07EA2438F71A002F1D12 /* PagingDistanceLeftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDistanceLeftTests.swift; sourceTree = "<group>"; };
 		95B301161E59FCD500B95D02 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		95D2AE35242BB22F00AC3D46 /* PageViewDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewDirection.swift; sourceTree = "<group>"; };
 		95D2AE37242BB24800AC3D46 /* PageViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewState.swift; sourceTree = "<group>"; };
@@ -434,10 +442,14 @@
 				95591F20222C3A0400677B4B /* PagingControllerTests.swift */,
 				3E5E93E81CE7E093000762A1 /* PagingDataStructureTests.swift */,
 				954842621F4252070072038C /* PagingDiffTests.swift */,
+				9575BEB62463490B002403F6 /* PagingDistanceCenteredTests.swift */,
+				95AD07EA2438F71A002F1D12 /* PagingDistanceLeftTests.swift */,
+				9575BEB42462034B002403F6 /* PagingDistanceRightTests.swift */,
 				3EFEFBF61C80B8820023C949 /* PagingIndicatorLayoutAttributesTests.swift */,
 				3E5E93E21CE7D899000762A1 /* PagingStateTests.swift */,
 				954842601F4251F90072038C /* PagingViewControllerTests.swift */,
 				95D78FE5228728FD00E6EE7C /* Mocks */,
+				9575BEB12461FEE3002403F6 /* Utilities */,
 			);
 			path = ParchmentTests;
 			sourceTree = "<group>";
@@ -667,6 +679,14 @@
 				955453F22415181500923BC8 /* StoryboardViewController.swift */,
 			);
 			path = Storyboard;
+			sourceTree = "<group>";
+		};
+		9575BEB12461FEE3002403F6 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				9575BEB22461FEF9002403F6 /* CreateDistance.swift */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 		95D2AE42242BC1FA00AC3D46 /* ParchmentUITests */ = {
@@ -938,17 +958,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9575BEB52462034B002403F6 /* PagingDistanceRightTests.swift in Sources */,
 				95FEEA512423F752009B5B64 /* MockPageViewManagerDataSource.swift in Sources */,
 				95D78FE1228715E100E6EE7C /* MockPagingControllerDataSource.swift in Sources */,
 				3E5E93E91CE7E093000762A1 /* PagingDataStructureTests.swift in Sources */,
+				95AD07EB2438F71A002F1D12 /* PagingDistanceLeftTests.swift in Sources */,
 				95D78FEC2288343F00E6EE7C /* MockPagingControllerSizeDelegate.swift in Sources */,
 				95FEEA4D2423C44A009B5B64 /* MockPageViewManagerDelegate.swift in Sources */,
 				95591F21222C3A0400677B4B /* PagingControllerTests.swift in Sources */,
 				95D78FDF228715C800E6EE7C /* MockPagingControllerDelegate.swift in Sources */,
 				3E5E93E31CE7D899000762A1 /* PagingStateTests.swift in Sources */,
 				951E163720A21D3A0055E9D4 /* PagingViewControllerTests.swift in Sources */,
+				9575BEB32461FEF9002403F6 /* CreateDistance.swift in Sources */,
 				95FEEA4524215FCA009B5B64 /* PageViewManagerTests.swift in Sources */,
 				95D78FDB2287138F00E6EE7C /* MockCollectionView.swift in Sources */,
+				9575BEB72463490B002403F6 /* PagingDistanceCenteredTests.swift in Sources */,
 				954E7DEE1F48AE6E00342ECF /* Item.swift in Sources */,
 				954842631F4252070072038C /* PagingDiffTests.swift in Sources */,
 				95D78FDD228713B800E6EE7C /* MockCollectionViewLayout.swift in Sources */,

--- a/Parchment/Classes/PagingController.swift
+++ b/Parchment/Classes/PagingController.swift
@@ -474,12 +474,13 @@ final class PagingController: NSObject {
       visibleItems: visibleItems,
       sizeCache: sizeCache,
       selectedScrollPosition: options.selectedScrollPosition,
-      layoutAttributes: collectionViewLayout.layoutAttributes
+      layoutAttributes: collectionViewLayout.layoutAttributes,
+      navigationOrientation: options.contentNavigationOrientation
     )
     
     return PagingTransition(
       contentOffset: collectionView.contentOffset,
-      distance: distance.calculate()
+      distance: distance?.calculate() ?? 0
     )
   }
   

--- a/Parchment/Structs/PagingDistance.swift
+++ b/Parchment/Structs/PagingDistance.swift
@@ -2,29 +2,132 @@ import Foundation
 import UIKit
 
 struct PagingDistance {
+  private let view: CollectionView
+  private let hasItemsBefore: Bool
+  private let hasItemsAfter: Bool
+  private let fromItem: PagingItem
+  private let fromAttributes: PagingCellLayoutAttributes?
+  private let toItem: PagingItem
+  private let toAttributes: PagingCellLayoutAttributes
+  private let selectedScrollPosition: PagingSelectedScrollPosition
+  private let sizeCache: PagingSizeCache
+  private let navigationOrientation: PagingNavigationOrientation
   
-  let view: CollectionView
-  let currentPagingItem: PagingItem
-  let upcomingPagingItem: PagingItem
-  let visibleItems: PagingItems
-  let sizeCache: PagingSizeCache
-  let selectedScrollPosition: PagingSelectedScrollPosition
-  let layoutAttributes: [IndexPath: PagingCellLayoutAttributes]
+  private var fromSize: CGFloat {
+    guard let attributes = fromAttributes else { return 0 }
+    switch navigationOrientation {
+    case .vertical:
+      return attributes.bounds.height
+    case .horizontal:
+      return attributes.bounds.width
+    }
+  }
+  
+  private var fromCenter: CGFloat {
+    guard let attributes = fromAttributes else { return 0 }
+    switch navigationOrientation {
+    case .vertical:
+      return attributes.center.y
+    case .horizontal:
+      return attributes.center.x
+    }
+  }
+  
+  private var toSize: CGFloat {
+    switch navigationOrientation {
+    case .vertical:
+      return toAttributes.bounds.height
+    case .horizontal:
+      return toAttributes.bounds.width
+    }
+  }
+  
+  private var toCenter: CGFloat {
+    switch navigationOrientation {
+    case .vertical:
+      return toAttributes.center.y
+    case .horizontal:
+      return toAttributes.center.x
+    }
+  }
+  
+  private var contentOffset: CGFloat {
+    switch navigationOrientation {
+    case .vertical:
+      return view.contentOffset.y
+    case .horizontal:
+      return view.contentOffset.x
+    }
+  }
+  
+  private var contentSize: CGFloat {
+    switch navigationOrientation {
+    case .vertical:
+      return view.contentSize.height
+    case .horizontal:
+      return view.contentSize.width
+    }
+  }
+  
+  private var viewSize: CGFloat {
+    switch navigationOrientation {
+    case .vertical:
+      return view.bounds.height
+    case .horizontal:
+      return view.bounds.width
+    }
+  }
+  
+  private var viewCenter: CGFloat {
+    switch navigationOrientation {
+    case .vertical:
+      return view.bounds.midY
+    case .horizontal:
+      return view.bounds.midX
+    }
+  }
+  
+  init?(
+    view: CollectionView,
+    currentPagingItem: PagingItem,
+    upcomingPagingItem: PagingItem,
+    visibleItems: PagingItems,
+    sizeCache: PagingSizeCache,
+    selectedScrollPosition: PagingSelectedScrollPosition,
+    layoutAttributes: [IndexPath: PagingCellLayoutAttributes],
+    navigationOrientation: PagingNavigationOrientation
+  ) {
+    guard
+      let upcomingIndexPath = visibleItems.indexPath(for: upcomingPagingItem),
+      let upcomingAttributes = layoutAttributes[upcomingIndexPath] else {
+        // When there is no upcomingIndexPath or any layout attributes
+        // for that item we have no way to determine the distance.
+        return nil
+    }
+    
+    self.view = view
+    self.hasItemsBefore = visibleItems.hasItemsBefore
+    self.hasItemsAfter = visibleItems.hasItemsAfter
+    self.fromItem = currentPagingItem
+    self.toItem = upcomingPagingItem
+    self.toAttributes = upcomingAttributes
+    self.selectedScrollPosition = selectedScrollPosition
+    self.sizeCache = sizeCache
+    self.navigationOrientation = navigationOrientation
+    
+    if let currentIndexPath = visibleItems.indexPath(for: currentPagingItem),
+      let fromAttributes = layoutAttributes[currentIndexPath] {
+      self.fromAttributes = fromAttributes
+    } else {
+      self.fromAttributes = nil
+    }
+  }
   
   /// In order to get the menu items to scroll alongside the content
   /// we create a transition struct to keep track of the initial
   /// content offset and the distance to the upcoming item so that we
   /// can update the content offset as the user is swiping.
   func calculate() -> CGFloat {
-    guard
-      let upcomingIndexPath = visibleItems.indexPath(for: upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else {
-        
-        // When there is no upcomingIndexPath or any layout attributes
-        // for that item we have no way to determine the distance.
-        return 0
-    }
-    
     var distance: CGFloat = 0
     
     switch (selectedScrollPosition) {
@@ -38,30 +141,27 @@ struct PagingDistance {
     
     // Update the distance to account for cases where the user has
     // scrolled all the way over to the other edge.
-    if view.near(edge: .left, clearance: -distance) && distance < 0 && visibleItems.hasItemsBefore == false {
-      distance = -(view.contentOffset.x + view.contentInset.left)
-    } else if view.near(edge: .right, clearance: distance) && distance > 0 &&
-      visibleItems.hasItemsAfter == false {
-      
+    if view.near(edge: .left, clearance: -distance) && distance < 0 && hasItemsBefore == false {
+      distance = -(contentOffset + view.contentInset.left)
+    } else if view.near(edge: .right, clearance: distance) && distance > 0 && hasItemsAfter == false {
       let originalDistance = distance
-      distance = view.contentSize.width - (view.contentOffset.x + view.bounds.width)
+      distance = contentSize - (contentOffset + viewSize)
       
       if sizeCache.implementsWidthDelegate {
-        let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
-        distance += toWidth - to.bounds.width
+        let toWidth = sizeCache.itemWidthSelected(for: toItem)
+        distance += toWidth - toSize
         
-        if let currentIndexPath = visibleItems.indexPath(for: currentPagingItem),
-          let from = layoutAttributes[currentIndexPath] {
-          let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
-          distance -= from.bounds.width - fromWidth
+        if let _ = fromAttributes {
+          let fromWidth = sizeCache.itemWidth(for: fromItem)
+          distance -= fromSize - fromWidth
         }
         
         // If the selected cells grows so much that it will move
         // beyond the center of the view, we want to update the
         // distance after all.
         if selectedScrollPosition == .preferCentered {
-          let center = view.bounds.midX
-          let centerAfterTransition = to.center.x - distance
+          let center = viewCenter
+          let centerAfterTransition = toCenter - distance
           if centerAfterTransition < center {
             distance = originalDistance
           }
@@ -73,18 +173,21 @@ struct PagingDistance {
   }
   
   private func distanceLeft() -> CGFloat {
-    guard
-      let upcomingIndexPath = visibleItems.indexPath(for: upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
+    // Need to use the combination of center and size as the frame
+    // property will be affected by things like transforms etc.
+    let currentPosition = toCenter - (toSize / 2)
+    var distance = currentPosition - contentOffset
     
-    var distance = to.center.x - (to.bounds.width / 2) - view.contentOffset.x
-    
+    // When scrolling forwards, subtract the difference between the
+    // current width and the new selected width. If we're scrolling
+    // backwards or the current item is scrolled out of view the
+    // difference doesn't matter as the change in frame of the current
+    // item won't have any affect on the position of the upcoming item.
     if sizeCache.implementsWidthDelegate {
-      if let currentIndexPath = visibleItems.indexPath(for: currentPagingItem),
-        let from = layoutAttributes[currentIndexPath] {
-        if currentPagingItem.isBefore(item: upcomingPagingItem) {
-          let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
-          let fromDiff = from.bounds.width - fromWidth
+      if let _ = fromAttributes {
+        if fromItem.isBefore(item: toItem) {
+          let fromWidth = sizeCache.itemWidth(for: fromItem)
+          let fromDiff = fromSize - fromWidth
           distance -= fromDiff
         }
       }
@@ -93,30 +196,36 @@ struct PagingDistance {
   }
   
   private func distanceRight() -> CGFloat {
-    guard
-      let upcomingIndexPath = visibleItems.indexPath(for: upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
-    
-    let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
-    let currentPosition = to.center.x + (to.bounds.width / 2)
-    let width = view.contentOffset.x + view.bounds.width
+    // Need to use the combination of center and size as the frame
+    // property will be affected by things like transforms etc.
+    let currentPosition = toCenter + (toSize / 2)
+    let width = contentOffset + viewSize
     var distance = currentPosition - width
     
     if sizeCache.implementsWidthDelegate {
-      if let currentIndexPath = visibleItems.indexPath(for: currentPagingItem),
-        let from = layoutAttributes[currentIndexPath] {
-        if upcomingPagingItem.isBefore(item: currentPagingItem) {
-          let toDiff = toWidth - to.bounds.width
+      let toWidth = sizeCache.itemWidthSelected(for: toItem)
+      
+      // If we have layout attributes for the current item it means
+      // the item is visible and will affect the on the position of
+      // the upcoming item when we change its frame. We therefore need
+      // to subtract the difference of the size.
+      if let _ = fromAttributes {
+        if toItem.isBefore(item: fromItem) {
+          let toDiff = toWidth - toSize
           distance += toDiff
         } else {
-          let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
-          let fromDiff = from.bounds.width - fromWidth
-          let toDiff = toWidth - to.bounds.width
+          let fromWidth = sizeCache.itemWidth(for: fromItem)
+          let fromDiff = fromSize - fromWidth
+          let toDiff = toWidth - toSize
           distance -= fromDiff
           distance += toDiff
         }
       } else {
-        distance += toWidth - to.bounds.width
+        // If we don't have any attributes for the current item it
+        // means we have scrolled it out of view before selecting the
+        // upcoming item. We need to append the difference between the
+        // selected and none-selected with of the upcoming item.
+        distance += toWidth - toSize
       }
     }
     
@@ -124,32 +233,27 @@ struct PagingDistance {
   }
   
   private func distanceCentered() -> CGFloat {
-    guard
-      let upcomingIndexPath = visibleItems.indexPath(for: upcomingPagingItem),
-      let to = layoutAttributes[upcomingIndexPath] else { return 0 }
+    var distance = toCenter - viewCenter
     
-    let toWidth = sizeCache.itemWidthSelected(for: upcomingPagingItem)
-    var distance = to.center.x - view.bounds.midX
-    
-    if let currentIndexPath = visibleItems.indexPath(for: currentPagingItem),
-      let from = layoutAttributes[currentIndexPath] {
-      
-      let distanceToCenter = view.bounds.midX - from.center.x
-      let distanceBetweenCells = to.center.x - from.center.x
+    if let _ = fromAttributes {
+      let distanceToCenter = viewCenter - fromCenter
+      let distanceBetweenCells = toCenter - fromCenter
       distance = distanceBetweenCells - distanceToCenter
       
       if sizeCache.implementsWidthDelegate {
-        let fromWidth = sizeCache.itemWidth(for: currentPagingItem)
+        let toWidth = sizeCache.itemWidthSelected(for: toItem)
+        let fromWidth = sizeCache.itemWidth(for: fromItem)
         
-        if upcomingPagingItem.isBefore(item: currentPagingItem) {
-          distance = -(to.bounds.width + (from.center.x - (to.center.x + (to.bounds.width / 2))) - (toWidth / 2)) - distanceToCenter
+        if toItem.isBefore(item: fromItem) {
+          distance = -(toSize + (fromCenter - (toCenter + (toSize / 2))) - (toWidth / 2)) - distanceToCenter
         } else {
-          let toDiff = (toWidth - to.bounds.width) / 2
-          distance = fromWidth + (to.center.x - (from.center.x + (from.bounds.width / 2))) + toDiff - (from.bounds.width / 2) - distanceToCenter
+          let toDiff = (toWidth - toSize) / 2
+          distance = fromWidth + (toCenter - (fromCenter + (fromSize / 2))) + toDiff - (fromSize / 2) - distanceToCenter
         }
       }
     } else if sizeCache.implementsWidthDelegate {
-      let toDiff = toWidth - to.bounds.width
+      let toWidth = sizeCache.itemWidthSelected(for: toItem)
+      let toDiff = toWidth - toSize
       distance += toDiff / 2
     }
     

--- a/ParchmentTests/PagingDistanceCenteredTests.swift
+++ b/ParchmentTests/PagingDistanceCenteredTests.swift
@@ -1,0 +1,356 @@
+import XCTest
+@testable import Parchment
+
+final class PagingDistanceCenteredTests: XCTestCase {
+  private var sizeCache: PagingSizeCache!
+  
+  override func setUp() {
+    sizeCache = PagingSizeCache(options: PagingOptions())
+  }
+  
+  /// Distance from centered item to upcoming item.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├──┐┌────────┐┌────────┐┌────────┐┌──┤
+  /// │  ││        ││  From  ││   To   ││  │
+  /// ├──┘└────────┘└────────┘└────────┘└──┤
+  /// └────────────────────────────────────┘
+  /// x: 100
+  /// ```
+  func testDistanceCentered() {
+    let distance = createDistance(
+      bounds: CGRect(x: 100, y: 0, width: 500, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 300, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 400, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 100)
+  }
+  
+  /// Distance from non-centered item to upcoming item.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├──┐┌────────┐┌────────┐┌────────┐┌──┤
+  /// │  ││  From  ││        ││   To   ││  │
+  /// ├──┘└────────┘└────────┘└────────┘└──┤
+  /// └────────────────────────────────────┘
+  /// x: 100
+  /// ```
+  func testDistanceCenteredFromNotCentered() {
+    let distance = createDistance(
+      bounds: CGRect(x: 100, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 150, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 350, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 100)
+  }
+  
+  /// Distance to already centered item.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├──┐┌────────┐┌────────┐┌────────┐┌──┤
+  /// │  ││  From  ││   To   ││        ││  │
+  /// ├──┘└────────┘└────────┘└────────┘└──┤
+  /// └────────────────────────────────────┘
+  /// x: 100
+  /// ```
+  func testDistanceCenteredToAlreadyCentered() {
+    let distance = createDistance(
+      bounds: CGRect(x: 100, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 150, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 250, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 0)
+  }
+  
+  /// Distance from larger, centered item to smaller item after.
+  ///
+  /// ```
+  /// ┌──────────────────────────────────────┐
+  /// ├───┐┌───┐┌───┐┌────────┐┌───┐┌───┐┌───┤
+  /// │   ││   ││   ││  From  ││To ││   ││   │
+  /// ├───┘└───┘└───┘└────────┘└───┘└───┘└───┤
+  /// └──────────────────────────────────────┘
+  /// x: 100
+  /// ```
+  func testDistanceCenteredUsingSizeDelegateScrollingForward() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 100, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 150, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 250, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, -50)
+  }
+  
+  /// Distance from larger, centered item to smaller item before.
+  ///
+  /// ```
+  /// ┌──────────────────────────────────────┐
+  /// ├───┐┌───┐┌───┐┌────────┐┌───┐┌───┐┌───┤
+  /// │   ││   ││To ││  From  ││   ││   ││   │
+  /// ├───┘└───┘└───┘└────────┘└───┘└───┘└───┤
+  /// └──────────────────────────────────────┘
+  /// x: 100
+  /// ```
+  func testDistanceCenteredUsingSizeDelegateScrollingBackward() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 100, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 1),
+      currentItemBounds: CGRect(x: 150, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 0),
+      upcomingItemBounds: CGRect(x: 100, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, -100)
+  }
+  
+  /// Distance from an item scrolled out of view (so we don't have any
+  /// layout attributes) to an item all the way on the other side.
+  ///
+  /// ```
+  ///                ┌──────────────────────────────────────┐
+  /// ┌────────┐     ├───┐┌───┐┌───┐┌───┐┌───┐┌───┐┌───┐┌───┤
+  /// │  From  │ ... │   ││   ││   ││   ││   ││To ││   ││   │
+  /// └────────┘     ├───┘└───┘└───┘└───┘└───┘└───┘└───┘└───┤
+  ///                └──────────────────────────────────────┘
+  ///                 x: 200
+  /// ```
+  func testDistanceCenteredUsingSizeDelegateWithoutFromAttributes() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 200, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 2000, height: 50),
+      currentItem: Item(index: 1),
+      currentItemBounds: nil,
+      upcomingItem: Item(index: 0),
+      upcomingItemBounds: CGRect(x: 450, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 100)
+  }
+  
+  /// Distance to item at the leading edge so it cannot be centered.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├────────┐┌────────┐┌────────┐┌──────┤
+  /// │   To   ││        ││  From  ││      │
+  /// ├────────┘└────────┘└────────┘└──────┤
+  /// └────────────────────────────────────┘
+  /// x: 0
+  /// ```
+  func testDistanceCenteredToLeadingEdge() {
+    let distance = createDistance(
+      bounds: CGRect(x: 0, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 400, height: 50),
+      currentItem: Item(index: 1),
+      currentItemBounds: CGRect(x: 200, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 0),
+      upcomingItemBounds: CGRect(x: 0, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 0)
+  }
+  
+  /// Distance to item at the leading edge so it cannot be centered,
+  /// when using the size delegate.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├───┐┌───┐┌───┐┌───┐┌────────┐┌───┐┌─┤
+  /// │To ││   ││   ││   ││  From  ││   ││ │
+  /// ├───┘└───┘└───┘└───┘└────────┘└───┘└─┤
+  /// └────────────────────────────────────┘
+  /// x: 0
+  /// ```
+  func testDistanceCenteredToLeadingEdgeWhenUsingSizeDelegate() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 0, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 400, height: 50),
+      currentItem: Item(index: 1),
+      currentItemBounds: CGRect(x: 200, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 0),
+      upcomingItemBounds: CGRect(x: 0, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 0)
+  }
+  
+  /// Distance to item at the trailing edge so it cannot be centered.
+  ///
+  /// ```
+  /// ┌──────────────────────────────────────┐
+  /// ├────────┐┌────────┐┌────────┐┌────────┤
+  /// │        ││  From  ││        ││   To   │
+  /// ├────────┘└────────┘└────────┘└────────┤
+  /// └──────────────────────────────────────┘
+  /// x: 600
+  /// ```
+  func testDistanceCenteredToTrailingEdge() {
+    let distance = createDistance(
+      bounds: CGRect(x: 600, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 700, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 900, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 0)
+  }
+  
+  /// Distance to item at the trailing edge so it cannot be centered,
+  /// when using the size delegate.
+  ///
+  /// ```
+  /// ┌──────────────────────────────────────┐
+  /// ├───┐┌───┐┌────────┐┌───┐┌───┐┌───┐┌───┤
+  /// │   ││   ││  From  ││   ││   ││   ││To │
+  /// ├───┘└───┘└────────┘└───┘└───┘└───┘└───┤
+  /// └──────────────────────────────────────┘
+  /// x: 600
+  /// ```
+  func testDistanceCenteredToTrailingEdgeWhenUsingSizeDelegate() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 600, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 700, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 950, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 0)
+  }
+  
+  /// Distance to item at the trailing edge when using the size
+  /// delegate, with selected width so large that the items can be
+  /// centered after the transition.
+  ///
+  /// ```
+  ///                               ┌──────────────────────────────────────┐
+  /// ┌─────────────────────────────┴──────────────────┐┌───┐┌───┐┌───┐┌───┤
+  /// │                      From                      ││   ││   ││   ││To │
+  /// └─────────────────────────────┬──────────────────┘└───┘└───┘└───┘└───┤
+  ///                               └──────────────────────────────────────┘
+  ///                               x: 600
+  /// ```
+  func testDistanceCenteredToTrailingEdgeWhenUsingSizeDelegateWithHugeSelectedWidth() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 500
+      } else {
+        return 50
+      }
+    }
+    
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 600, y: 0, width: 400, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 300, y: 0, width: 500, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 950, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .preferCentered,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, -50)
+  }
+}

--- a/ParchmentTests/PagingDistanceLeftTests.swift
+++ b/ParchmentTests/PagingDistanceLeftTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import Parchment
+
+final class PagingDistanceLeftTests: XCTestCase {
+  private var sizeCache: PagingSizeCache!
+  
+  override func setUp() {
+    sizeCache = PagingSizeCache(options: PagingOptions())
+  }
+  
+  /// Distance from left aligned item to upcoming item.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├────────┐┌────────┐┌───────┐┌───────┤
+  /// │  From  ││   To   ││       ││       │
+  /// ├────────┘└────────┘└───────┘└───────┤
+  /// └────────────────────────────────────┘
+  /// x: 0
+  /// ```
+  func testDistanceLeft() {
+    let distance = createDistance(
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 0, y: 0, width: 100, height: 100),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 100, y: 0, width: 100, height: 100),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .left,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 100)
+  }
+  
+  /// Distance from left aligned item to upcoming item with other
+  /// items in between.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├────────┐┌────────┐┌────────┐┌──────┤
+  /// │  From  ││        ││   To   ││      │
+  /// ├────────┘└────────┘└────────┘└──────┤
+  /// └────────────────────────────────────┘
+  /// x: 0
+  /// ```
+  func testDistanceLeftWithItemsBetween() {
+    let distance = createDistance(
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 0, y: 0, width: 100, height: 100),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 200, y: 0, width: 100, height: 100),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .left,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 200)
+  }
+  
+  /// Distance to upcoming item when scrolled slightly.
+  ///
+  /// ```
+  ///      ┌────────────────────────────────────┐
+  /// ┌────┴───┐┌────────┐┌───────┐┌───────┐┌───┤
+  /// │  From  ││   To   ││       ││       ││   │
+  /// └────┬───┘└────────┘└───────┘└───────┘└───┤
+  ///      └────────────────────────────────────┘
+  ///      x: 50
+  /// ```
+  func testDistanceLeftWithContentOffset() {
+    let distance = createDistance(
+      bounds: CGRect(origin: CGPoint(x: 50, y: 0), size: .zero),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 0, y: 0, width: 100, height: 100),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 100, y: 0, width: 100, height: 100),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .left,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 50)
+  }
+  
+  /// Distance from larger, left-aligned item positioned before
+  /// smaller upcoming item.
+  ///
+  /// ```
+  ///             ┌───────────────────────────────────────┐
+  /// ┌────┐┌────┐├──────────┐┌────┐┌────┐┌────┐┌────┐┌───┤
+  /// │    ││    ││   From   ││ To ││    ││    ││    ││   │
+  /// └────┘└────┘├──────────┘└────┘└────┘└────┘└────┘└───┤
+  ///             └───────────────────────────────────────┘
+  ///             x: 500
+  /// ```
+  func testDistanceLeftUsingSizeDelegateScrollingForward() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(origin: CGPoint(x: 500, y: 0), size: .zero),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 500, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 600, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .left,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 50)
+  }
+  
+  /// Distance from larger, left-aligned item positioned after
+  /// smaller larger item.
+  ///
+  /// ```
+  ///             ┌───────────────────────────────────────┐
+  /// ┌────┐┌────┐├──────────┐┌────┐┌────┐┌────┐┌────┐┌───┤
+  /// │    ││ To ││   From   ││    ││    ││    ││    ││   │
+  /// └────┘└────┘├──────────┘└────┘└────┘└────┘└────┘└───┤
+  ///             └───────────────────────────────────────┘
+  ///             x: 500
+  /// ```
+  func testDistanceLeftUsingSizeDelegateScrollingBackward() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      // Expects it to ignore this value when scrolling backwards so
+      // setting it the a big number to notice if it's being used.
+      return 1000
+    }
+    
+    let distance = createDistance(
+    bounds: CGRect(origin: CGPoint(x: 500, y: 0), size: .zero),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 1),
+      currentItemBounds: CGRect(x: 500, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 0),
+      upcomingItemBounds: CGRect(x: 450, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .left,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, -50)
+  }
+}

--- a/ParchmentTests/PagingDistanceRightTests.swift
+++ b/ParchmentTests/PagingDistanceRightTests.swift
@@ -1,0 +1,196 @@
+import XCTest
+@testable import Parchment
+
+final class PagingDistanceRightTests: XCTestCase {
+  private var sizeCache: PagingSizeCache!
+  
+  override func setUp() {
+    sizeCache = PagingSizeCache(options: PagingOptions())
+  }
+  
+  /// Distance from right aligned item to upcoming item.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// │                           ┌────────┤┌────────┐┌────────┐┌────────┐
+  /// │                           │  From  ││   To   ││        ││        │
+  /// │                           └────────┤└────────┘└────────┘└────────┘
+  /// └────────────────────────────────────┘
+  /// x: 0
+  /// ```
+  func testDistanceRight() {
+    let distance = createDistance(
+      bounds: CGRect(x: 0, y: 0, width: 500, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 400, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 500, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .right,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 100)
+  }
+  
+  /// Distance from right aligned item to upcoming item.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// │                           ┌────────┤┌────────┐┌────────┐┌────────┐
+  /// │                           │  From  ││        ││   To   ││        │
+  /// │                           └────────┤└────────┘└────────┘└────────┘
+  /// └────────────────────────────────────┘
+  /// x: 0
+  /// ```
+  func testDistanceRightWithItemsBetween() {
+    let distance = createDistance(
+      bounds: CGRect(x: 0, y: 0, width: 500, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 400, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 2),
+      upcomingItemBounds: CGRect(x: 600, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .right,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 200)
+  }
+  
+  /// Distance to upcoming item when scrolled slightly.
+  ///
+  /// ```
+  /// ┌────────────────────────────────────┐
+  /// ├──────┐┌────────┐┌────────┐┌────────┤┌────────┐
+  /// │      ││        ││        ││  From  ││   To   │
+  /// ├──────┘└────────┘└────────┘└────────┤└────────┘
+  /// └────────────────────────────────────┘
+  /// x: 50
+  /// ```
+  func testDistanceRightWithContentOffset() {
+    let distance = createDistance(
+      bounds: CGRect(x: 50, y: 0, width: 500, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 400, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 500, y: 0, width: 100, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .right,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 50)
+  }
+  
+  /// Distance from larger, right-aligned item positioned before
+  /// smaller upcoming item.
+  ///
+  /// ```
+  /// ┌───────────────────────────────────────┐
+  /// │    ┌────┐┌────┐┌────┐┌────┐┌──────────┤┌────┐┌────┐
+  /// │    │    ││    ││    ││    ││   From   ││ To ││    │
+  /// │    └────┘└────┘└────┘└────┘└──────────┤└────┘└────┘
+  /// └───────────────────────────────────────┘
+  /// x: 0
+  /// ```
+  func testDistanceRightUsingSizeDelegateScrollingForward() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 0, y: 0, width: 500, height: 50),
+      contentSize: CGSize(width: 1000, height: 50),
+      currentItem: Item(index: 0),
+      currentItemBounds: CGRect(x: 500, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 1),
+      upcomingItemBounds: CGRect(x: 500, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .right,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 50)
+  }
+  
+  /// Distance from larger, right-aligned item positioned after
+  /// smaller larger item.
+  ///
+  /// ```
+  /// ┌───────────────────────────────────────┐
+  /// ├───┐┌────┐┌────┐┌────┐┌────┐┌──────────┤┌────┐┌────┐
+  /// │   ││    ││    ││    ││ To ││   From   ││    ││    │
+  /// ├───┘└────┘└────┘└────┘└────┘└──────────┤└────┘└────┘
+  /// └───────────────────────────────────────┘
+  /// x: 200
+  /// ```
+  func testDistanceRightUsingSizeDelegateScrollingBackward() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 200, y: 0, width: 500, height: 50),
+      contentSize: CGSize(width: 2000, height: 50),
+      currentItem: Item(index: 1),
+      currentItemBounds: CGRect(x: 600, y: 0, width: 100, height: 50),
+      upcomingItem: Item(index: 0),
+      upcomingItemBounds: CGRect(x: 550, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .right,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, -50)
+  }
+  
+  /// Distance from an item scrolled out of view (so we don't have any
+  /// layout attributes) to an item all the way on the other side.
+  ///
+  /// ```
+  ///                  ┌───────────────────────────────────────┐
+  /// ┌──────────┐    ┌┴───┐┌────┐┌────┐┌────┐┌────┐┌────┐┌────┤
+  /// │   From   │ ...│    ││    ││    ││    ││    ││    ││ To │
+  /// └──────────┘    └┬───┘└────┘└────┘└────┘└────┘└────┘└────┤
+  ///                  └───────────────────────────────────────┘
+  ///                  x: 200
+  /// ```
+  func testDistanceRightUsingSizeDelegateWithoutFromAttributes() {
+    sizeCache.implementsWidthDelegate = true
+    sizeCache.widthForPagingItem = { item, isSelected in
+      if isSelected {
+         return 100
+      } else {
+        return 50
+      }
+    }
+    
+    let distance = createDistance(
+      bounds: CGRect(x: 200, y: 0, width: 500, height: 50),
+      contentSize: CGSize(width: 2000, height: 50),
+      currentItem: Item(index: 1),
+      currentItemBounds: nil,
+      upcomingItem: Item(index: 0),
+      upcomingItemBounds: CGRect(x: 650, y: 0, width: 50, height: 50),
+      sizeCache: sizeCache,
+      selectedScrollPosition: .right,
+      navigationOrientation: .horizontal)
+    
+    let value = distance.calculate()
+    XCTAssertEqual(value, 50)
+  }
+}

--- a/ParchmentTests/Utilities/CreateDistance.swift
+++ b/ParchmentTests/Utilities/CreateDistance.swift
@@ -1,0 +1,53 @@
+import Foundation
+@testable import Parchment
+
+func createDistance(
+  bounds: CGRect = .zero,
+  contentSize: CGSize? = nil,
+  currentItem: Item,
+  currentItemBounds: CGRect?,
+  upcomingItem: Item,
+  upcomingItemBounds: CGRect,
+  sizeCache: PagingSizeCache,
+  selectedScrollPosition: PagingSelectedScrollPosition,
+  navigationOrientation: PagingNavigationOrientation
+) -> PagingDistance {
+  let collectionView = MockCollectionView()
+  collectionView.contentOffset = bounds.origin
+  collectionView.bounds = bounds
+  
+  if let contentSize = contentSize {
+    collectionView.contentSize = contentSize
+  } else if let currentItemBounds = currentItemBounds {
+    let contentFrame = currentItemBounds.union(upcomingItemBounds)
+    collectionView.contentSize = contentFrame.size
+  } else {
+    collectionView.contentSize = upcomingItemBounds.size
+  }
+  
+  let visibleItems = PagingItems(items: [currentItem, upcomingItem])
+  var layoutAttributes: [IndexPath: PagingCellLayoutAttributes] = [:]
+  
+  if let currentItemBounds = currentItemBounds {
+    let currentIndexPath = visibleItems.indexPath(for: currentItem)!
+    let currentAttributes = PagingCellLayoutAttributes(forCellWith: currentIndexPath)
+    currentAttributes.frame = currentItemBounds
+    layoutAttributes[currentIndexPath] = currentAttributes
+  }
+  
+  let upcomingIndexPath = visibleItems.indexPath(for: upcomingItem)!
+  let upcomingAttributes = PagingCellLayoutAttributes(forCellWith: upcomingIndexPath)
+  upcomingAttributes.frame = upcomingItemBounds
+  layoutAttributes[upcomingIndexPath] = upcomingAttributes
+  
+  return PagingDistance(
+    view: collectionView,
+    currentPagingItem: currentItem,
+    upcomingPagingItem: upcomingItem,
+    visibleItems: visibleItems,
+    sizeCache: sizeCache,
+    selectedScrollPosition: selectedScrollPosition,
+    layoutAttributes: layoutAttributes,
+    navigationOrientation: navigationOrientation
+  )!
+}


### PR DESCRIPTION
PagingDistance is responsible for calculating the distance that the
collection view has to travel when selecting an item. This is used to
ensure a smooth transition. This commit refactors the calculation to
work with both vertical and horizontal layouts and introduces unit
tests for the most of the possible cases.