### PR TITLE
SwiftUI Wrapper(Page View) refactoring

### DIFF
--- a/ExampleSwiftUI/ContentView.swift
+++ b/ExampleSwiftUI/ContentView.swift
@@ -1,18 +1,58 @@
-import UIKit
-import SwiftUI
 import Parchment
+import SwiftUI
+import UIKit
 
 struct ContentView: View {
-  var body: some View {
-    return PageView(items: [
-      PagingIndexItem(index: 0, title: "View 0"),
-      PagingIndexItem(index: 1, title: "View 1"),
-      PagingIndexItem(index: 2, title: "View 2"),
-      PagingIndexItem(index: 3, title: "View 3")
-    ]) { item in
-      Text(item.title)
-        .font(.largeTitle)
-        .foregroundColor(.gray)
+    @State
+    var scrollToPosition: PageView.ScrollPosition?
+
+    var body: some View {
+        VStack {
+            Button(action: {
+                scrollToPosition = PageView.ScrollPosition(index: (0...3).randomElement()!)
+            }) {
+                Text("Random Index")
+                    .font(.largeTitle)
+            }
+            PageView(scrollToPosition: $scrollToPosition) {
+                PageView.TabItem(item: PagingIndexItem(index: 0, title: "View 0")) {
+                    List(0 ..< 100) { index in
+                        Text(String(index))
+                            .font(.largeTitle)
+                            .foregroundColor(.gray)
+                    }
+                }
+                PageView.TabItem(item: PagingIndexItem(index: 1, title: "View 1")) {
+                    List(0 ..< 100) { index in
+                        Text(String(index))
+                            .font(.largeTitle)
+                            .foregroundColor(.gray)
+                    }
+                }
+                PageView.TabItem(item: PagingIndexItem(index: 2, title: "View 2")) {
+                    List(0 ..< 100) { index in
+                        Text(String(index))
+                            .font(.largeTitle)
+                            .foregroundColor(.gray)
+                    }
+                }
+                PageView.TabItem(item: PagingIndexItem(index: 3, title: "View 3")) {
+                    List(0 ..< 100) { index in
+                        Text(String(index))
+                            .font(.largeTitle)
+                            .foregroundColor(.gray)
+                    }
+                }
+            }
+            .willScroll { index in
+                print("willScroll: \(index)")
+            }
+            .didScroll { index in
+                print("didScroll: \(index)")
+            }
+            .didSelect { index in
+                print("didSelect: \(index)")
+            }
+        }
     }
-  }
 }

--- a/ExampleSwiftUI/ContentView.swift
+++ b/ExampleSwiftUI/ContentView.swift
@@ -44,14 +44,14 @@ struct ContentView: View {
                     }
                 }
             }
-            .willScroll { index in
-                print("willScroll: \(index)")
+            .willScroll { pagingItem in
+                print("willScroll: \(pagingItem)")
             }
-            .didScroll { index in
-                print("didScroll: \(index)")
+            .didScroll { pagingItem in
+                print("didScroll: \(pagingItem)")
             }
-            .didSelect { index in
-                print("didSelect: \(index)")
+            .didSelect { pagingItem in
+                print("didSelect: \(pagingItem)")
             }
         }
     }

--- a/ExampleSwiftUI/ContentView.swift
+++ b/ExampleSwiftUI/ContentView.swift
@@ -3,45 +3,29 @@ import SwiftUI
 import UIKit
 
 struct ContentView: View {
+    let items = [
+        PagingIndexItem(index: 0, title: "View 0"),
+        PagingIndexItem(index: 1, title: "View 1"),
+        PagingIndexItem(index: 2, title: "View 2"),
+        PagingIndexItem(index: 3, title: "View 3"),
+        PagingIndexItem(index: 4, title: "View 4"),
+    ]
     @State
-    var scrollToPosition: PageView.ScrollPosition?
+    var scrollToPosition: PageViewScrollPosition?
 
     var body: some View {
         VStack {
             Button(action: {
-                scrollToPosition = PageView.ScrollPosition(index: (0...3).randomElement()!)
+                scrollToPosition = PageViewScrollPosition(index: (0 ... 3).randomElement()!)
             }) {
                 Text("Random Index")
                     .font(.largeTitle)
             }
-            PageView(scrollToPosition: $scrollToPosition) {
-                PageView.TabItem(item: PagingIndexItem(index: 0, title: "View 0")) {
-                    List(0 ..< 100) { index in
-                        Text(String(index))
-                            .font(.largeTitle)
-                            .foregroundColor(.gray)
-                    }
-                }
-                PageView.TabItem(item: PagingIndexItem(index: 1, title: "View 1")) {
-                    List(0 ..< 100) { index in
-                        Text(String(index))
-                            .font(.largeTitle)
-                            .foregroundColor(.gray)
-                    }
-                }
-                PageView.TabItem(item: PagingIndexItem(index: 2, title: "View 2")) {
-                    List(0 ..< 100) { index in
-                        Text(String(index))
-                            .font(.largeTitle)
-                            .foregroundColor(.gray)
-                    }
-                }
-                PageView.TabItem(item: PagingIndexItem(index: 3, title: "View 3")) {
-                    List(0 ..< 100) { index in
-                        Text(String(index))
-                            .font(.largeTitle)
-                            .foregroundColor(.gray)
-                    }
+            PageView(scrollToPosition: $scrollToPosition, items: items) { _ in
+                List(0 ..< 100) { index in
+                    Text(String(index))
+                        .font(.largeTitle)
+                        .foregroundColor(.gray)
                 }
             }
             .willScroll { pagingItem in
@@ -54,5 +38,11 @@ struct ContentView: View {
                 print("didSelect: \(pagingItem)")
             }
         }
+    }
+}
+
+extension ContentView: Equatable {
+    static func == (lhs: ContentView, rhs: ContentView) -> Bool {
+        lhs.items == rhs.items
     }
 }

--- a/ExampleSwiftUI/SceneDelegate.swift
+++ b/ExampleSwiftUI/SceneDelegate.swift
@@ -5,7 +5,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
 
   func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-    let contentView = ContentView()
+    let contentView = ContentView().equatable()
     
     if let windowScene = scene as? UIWindowScene {
         let window = UIWindow(windowScene: windowScene)

--- a/Parchment/Structs/PageView.swift
+++ b/Parchment/Structs/PageView.swift
@@ -14,9 +14,9 @@ import UIKit
     /// `PagingOptions` struct to customize the properties.
     @available(iOS 13.0, *)
     public struct PageView: View {
-        public typealias WillScrollCallback = ((Int) -> Void)
-        public typealias DidScrollCallback = ((Int) -> Void)
-        public typealias DidSelectCallback = ((Int) -> Void)
+        public typealias WillScrollCallback = ((PagingItem) -> Void)
+        public typealias DidScrollCallback = ((PagingItem) -> Void)
+        public typealias DidSelectCallback = ((PagingItem) -> Void)
         private let options: PagingOptions
         private var viewControllers = [UIHostingController<AnyView>]()
         private var items = [TabItem]()
@@ -111,8 +111,7 @@ import UIKit
                                       destinationViewController: UIViewController,
                                       transitionSuccessful: Bool)
             {
-                guard let index = (pagingItem as? PagingIndexItem)?.index else { return }
-                parent.didScrollCallback?(index)
+                parent.didScrollCallback?(pagingItem)
 
                 DispatchQueue.main.async {
                     self.parent.scrollToPosition = nil
@@ -124,13 +123,11 @@ import UIKit
                                       startingViewController: UIViewController,
                                       destinationViewController: UIViewController)
             {
-                guard let index = (pagingItem as? PagingIndexItem)?.index else { return }
-                parent.willScrollCallback?(index)
+                parent.willScrollCallback?(pagingItem)
             }
 
             func pagingViewController(_ pagingViewController: PagingViewController, didSelectItem pagingItem: PagingItem) {
-                guard let index = (pagingItem as? PagingIndexItem)?.index else { return }
-                parent.didSelectCallback?(index)
+                parent.didSelectCallback?(pagingItem)
             }
         }
     }

--- a/Parchment/Structs/PageView.swift
+++ b/Parchment/Structs/PageView.swift
@@ -1,5 +1,5 @@
-import UIKit
 import SwiftUI
+import UIKit
 
 /// Check if both SwiftUI and Combine is available. Without this
 /// xcodebuild fails, saying it can't find the SwiftUI types used
@@ -9,81 +9,187 @@ import SwiftUI
 /// https://forums.swift.org/t/weak-linking-of-frameworks-with-greater-deployment-targets/26017/24
 #if canImport(SwiftUI) && canImport(Combine)
 
-/// `PageView` provides a SwiftUI wrapper around `PagingViewController`.
-/// It can be used with any fixed array of `PagingItem`s. Use the
-/// `PagingOptions` struct to customize the properties.
-@available(iOS 13.0, *)
-public struct PageView<Item: PagingItem, Page: View>: View {
-  private let items: [Item]
-  private let options: PagingOptions
-  private let content: (Item) -> Page
-  
-  /// Initialize a new `PageView`.
-  ///
-  /// - Parameters:
-  ///   - options: The configuration parameters we want to customize.
-  ///   - items: The array of `PagingItem`s to display in the menu.
-  ///   - content: A callback that returns the `View` for each item.
-  public init(
-    options: PagingOptions = PagingOptions(),
-    items: [Item],
-    content: @escaping (Item) -> Page) {
-    self.options = options
-    self.items = items
-    self.content = content
-  }
-  
-  public var body: some View {
-    PagingController(
-      items: items,
-      options: options,
-      content: content)
-  }
-  
-  struct PagingController: UIViewControllerRepresentable {
-    let items: [Item]
-    let options: PagingOptions
-    let content: (Item) -> Page
-    
-    func makeCoordinator() -> Coordinator {
-      Coordinator(self)
-    }
-    
-    func makeUIViewController(context: UIViewControllerRepresentableContext<PagingController>) -> PagingViewController {
-      let pagingViewController = PagingViewController(options: options)
-      return pagingViewController
-    }
-    
-    func updateUIViewController(_ pagingViewController: PagingViewController, context: UIViewControllerRepresentableContext<PagingController>) {
-      context.coordinator.parent = self
-      
-      if pagingViewController.dataSource == nil {
-        pagingViewController.dataSource = context.coordinator
-      } else {
-        pagingViewController.reloadData()
-      }
-    }
-  }
+    /// `PageView` provides a SwiftUI wrapper around `PagingViewController`.
+    /// It can be used with any fixed array of `PagingItem`s. Use the
+    /// `PagingOptions` struct to customize the properties.
+    @available(iOS 13.0, *)
+    public struct PageView: View {
+        public typealias WillScrollCallback = ((Int) -> Void)
+        public typealias DidScrollCallback = ((Int) -> Void)
+        public typealias DidSelectCallback = ((Int) -> Void)
+        private let options: PagingOptions
+        private var viewControllers = [UIHostingController<AnyView>]()
+        private var items = [TabItem]()
+        @Binding
+        private var scrollToPosition: ScrollPosition?
+        var willScrollCallback: WillScrollCallback?
+        var didScrollCallback: DidScrollCallback?
+        var didSelectCallback: DidSelectCallback?
 
-  class Coordinator: PagingViewControllerDataSource {
-    var parent: PagingController
-    
-    init(_ pagingController: PagingController) {
-      self.parent = pagingController
+        /// Initialize a new `PageView`.
+        ///
+        /// - Parameters:
+        ///   - options: The configuration parameters we want to customize.
+        ///   - items: The array of `PagingItem`s to display in the menu.
+        ///   - content: A callback that returns the `View` for each item.
+        public init(options: PagingOptions = PagingOptions(),
+                    scrollToPosition: Binding<ScrollPosition?>? = nil,
+                    @TabBuilder _ content: () -> [TabItem])
+        {
+            self._scrollToPosition = scrollToPosition ?? .constant(nil)
+            self.options = options
+            self.items = content()
+            self.viewControllers = items.map { UIHostingController(rootView: $0.view) }
+        }
+
+        public var body: some View {
+            PagingController(items: items,
+                             options: options,
+                             viewControllers: viewControllers,
+                             scrollToPosition: $scrollToPosition,
+                             willScrollCallback: willScrollCallback,
+                             didScrollCallback: didScrollCallback,
+                             didSelectCallback: didSelectCallback)
+        }
+
+        struct PagingController: UIViewControllerRepresentable {
+            let items: [TabItem]
+            let options: PagingOptions
+            let viewControllers: [UIHostingController<AnyView>]
+            @Binding
+            var scrollToPosition: ScrollPosition?
+            var willScrollCallback: WillScrollCallback?
+            var didScrollCallback: DidScrollCallback?
+            var didSelectCallback: DidSelectCallback?
+
+            func makeCoordinator() -> Coordinator {
+                Coordinator(self)
+            }
+
+            func makeUIViewController(context: UIViewControllerRepresentableContext<PagingController>) -> PagingViewController {
+                let pagingViewController = PagingViewController(options: options)
+                pagingViewController.dataSource = context.coordinator
+                pagingViewController.delegate = context.coordinator
+                return pagingViewController
+            }
+
+            func updateUIViewController(_ pagingViewController: PagingViewController,
+                                        context: UIViewControllerRepresentableContext<PagingController>)
+            {
+                context.coordinator.parent = self
+
+                if let position = $scrollToPosition.wrappedValue {
+                    pagingViewController.select(index: position.index, animated: position.animated)
+                } else {
+                    pagingViewController.reloadData()
+                }
+            }
+        }
+
+        class Coordinator: NSObject, PagingViewControllerDataSource, PagingViewControllerDelegate {
+            var parent: PagingController
+
+            init(_ pagingController: PagingController) {
+                self.parent = pagingController
+            }
+
+            func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
+                parent.items.count
+            }
+
+            func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
+                parent.viewControllers[index]
+            }
+
+            func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
+                parent.items[index].item
+            }
+
+            func pagingViewController(_ pagingViewController: PagingViewController,
+                                      didScrollToItem pagingItem: PagingItem,
+                                      startingViewController: UIViewController?,
+                                      destinationViewController: UIViewController,
+                                      transitionSuccessful: Bool)
+            {
+                guard let index = (pagingItem as? PagingIndexItem)?.index else { return }
+                parent.didScrollCallback?(index)
+
+                DispatchQueue.main.async {
+                    self.parent.scrollToPosition = nil
+                }
+            }
+
+            func pagingViewController(_ pagingViewController: PagingViewController,
+                                      willScrollToItem pagingItem: PagingItem,
+                                      startingViewController: UIViewController,
+                                      destinationViewController: UIViewController)
+            {
+                guard let index = (pagingItem as? PagingIndexItem)?.index else { return }
+                parent.willScrollCallback?(index)
+            }
+
+            func pagingViewController(_ pagingViewController: PagingViewController, didSelectItem pagingItem: PagingItem) {
+                guard let index = (pagingItem as? PagingIndexItem)?.index else { return }
+                parent.didSelectCallback?(index)
+            }
+        }
     }
-    
-    func numberOfViewControllers(in pagingViewController: PagingViewController) -> Int {
-      return parent.items.count
+
+    @available(iOS 13.0, *)
+    public extension PageView {
+        @available(iOS 13.0, *)
+        struct TabItem {
+            var view: AnyView
+            var item: PagingItem
+
+            public init<V>(item: PagingItem, @ViewBuilder content: @escaping () -> V) where V: View {
+                self.item = item
+                self.view = AnyView(content())
+            }
+        }
+
+        struct ScrollPosition: Equatable {
+            public var index: Int
+            public var animated: Bool
+
+            public init(index: Int, animated: Bool = true) {
+                self.index = index
+                self.animated = animated
+            }
+        }
     }
-    
-    func pagingViewController(_: PagingViewController, viewControllerAt index: Int) -> UIViewController {
-      let view = parent.content(parent.items[index])
-      return UIHostingController(rootView: view)
+
+    @_functionBuilder
+    @available(iOS 13.0, *)
+    public enum TabBuilder {
+        public static func buildBlock(_ children: PageView.TabItem...) -> [PageView.TabItem] {
+            children
+        }
+
+        public static func buildBlock(_ component: PageView.TabItem) -> [PageView.TabItem] {
+            [component]
+        }
     }
-    
-    func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
-      return parent.items[index]
+
+    @available(iOS 13.0, *)
+    public extension PageView {
+        func didScroll(_ didScrollCallback: @escaping DidScrollCallback) -> Self {
+            var this = self
+            this.didScrollCallback = didScrollCallback
+            return this
+        }
+
+        func willScroll(_ willScrollCallback: @escaping WillScrollCallback) -> Self {
+            var this = self
+            this.willScrollCallback = willScrollCallback
+            return this
+        }
+
+        func didSelect(_ didSelectCallback: @escaping DidSelectCallback) -> Self {
+            var this = self
+            this.didSelectCallback = didSelectCallback
+            return this
+        }
     }
-  }
-}
+
 #endif

--- a/Parchment/Structs/PageView.swift
+++ b/Parchment/Structs/PageView.swift
@@ -14,9 +14,9 @@ import UIKit
     /// `PagingOptions` struct to customize the properties.
     @available(iOS 13.0, *)
     public struct PageView<Item: PagingItem, Page: View>: View where Item: Hashable {
-        public typealias WillScrollCallback = ((Item) -> Void)
-        public typealias DidScrollCallback = ((Item) -> Void)
-        public typealias DidSelectCallback = ((Item) -> Void)
+        public typealias WillScrollCallback = ((PagingItem) -> Void)
+        public typealias DidScrollCallback = ((PagingItem) -> Void)
+        public typealias DidSelectCallback = ((PagingItem) -> Void)
         private let options: PagingOptions
         private var items = [Item]()
         let content: (Item) -> Page
@@ -114,7 +114,7 @@ import UIKit
             }
 
             func pagingViewController(_ pagingViewController: PagingViewController,
-                                      didScrollToItem pagingItem: Item,
+                                      didScrollToItem pagingItem: PagingItem,
                                       startingViewController: UIViewController?,
                                       destinationViewController: UIViewController,
                                       transitionSuccessful: Bool)
@@ -127,14 +127,14 @@ import UIKit
             }
 
             func pagingViewController(_ pagingViewController: PagingViewController,
-                                      willScrollToItem pagingItem: Item,
+                                      willScrollToItem pagingItem: PagingItem,
                                       startingViewController: UIViewController,
                                       destinationViewController: UIViewController)
             {
                 parent.willScrollCallback?(pagingItem)
             }
 
-            func pagingViewController(_ pagingViewController: PagingViewController, didSelectItem pagingItem: Item) {
+            func pagingViewController(_ pagingViewController: PagingViewController, didSelectItem pagingItem: PagingItem) {
                 parent.didSelectCallback?(pagingItem)
             }
         }


### PR DESCRIPTION
Currently, PageView cannot save the state of the view due to the view life cycle of SwiftUI. (ex. scroll offset)

I changed the init design of the view to be similar to TabView, and solved the problem by utilizing UIHostingController.

In addition, I wrapped some delegates for personal use.

Added support for the scrollToPosition binding property.

Thanks for providing a good library.