### PR TITLE
Removed reference to 'UIApplication.shared' for Xcode 13 compatibility

### DIFF
--- a/Parchment/Classes/PageViewController.swift
+++ b/Parchment/Classes/PageViewController.swift
@@ -116,8 +116,6 @@ public final class PageViewController: UIViewController {
             if #available(iOS 9.0, *),
                 UIView.userInterfaceLayoutDirection(for: view.semanticContentAttribute) == .rightToLeft {
                 return true
-            } else if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
-                return true
             } else {
                 return false
             }


### PR DESCRIPTION
On Xcode 13 Beta 3 I'm not able to build the project and see this error:

> .../checkouts/Parchment/Parchment/Classes/PageViewController.swift:118:31: 'shared' is unavailable in application extensions for iOS: Use view controller based solutions where appropriate instead.

Since the deployment target for the project is iOS 9, I think the line:
`else if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft`

is not needed anymore, right?

I'm not sure if this is the best fix for the issue, so let me know what you think please.

