### PR TITLE
Fix issue with rotation when using SwiftUI wrapper

### DIFF
--- a/Parchment/Classes/PageViewController.swift
+++ b/Parchment/Classes/PageViewController.swift
@@ -166,11 +166,12 @@ public final class PageViewController: UIViewController {
         manager.viewDidDisappear(animated)
     }
 
-    public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.willTransition(to: newCollection, with: coordinator)
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        print("viewWillTransition: ", size)
         coordinator.animate(alongsideTransition: { _ in
             self.manager.viewWillTransitionSize()
-    })
+        })
     }
 
     // MARK: Public Methods

--- a/Parchment/Structs/PageView.swift
+++ b/Parchment/Structs/PageView.swift
@@ -34,7 +34,7 @@ import UIKit
         public init(
             options: PagingOptions = PagingOptions(),
             items: [Item],
-            selectedIndex: Binding<Int> = .constant(0),
+            selectedIndex: Binding<Int> = .constant(Int.max),
             content: @escaping (Item) -> Page
         ) {
             _selectedIndex = selectedIndex
@@ -134,8 +134,20 @@ import UIKit
                 // the new items the next time this method is called.
                 pagingViewController.items = items
 
-                let index = $selectedIndex.wrappedValue
-                pagingViewController.select(index: index, animated: true)
+                // HACK: If the user don't pass a selectedIndex binding, the
+                // default parameter is set to .constant(Int.max) which allows
+                // us to check here if a binding was passed in or not (it
+                // doesn't seem possible to make the binding itself optional).
+                // This check is needed because we cannot update a .constant
+                // value. When the user scroll to another page, the
+                // selectedIndex binding will always be the same, so calling
+                // `select(index:)` will select the wrong page. This fixes a bug
+                // where the wrong page would be selected when rotating.
+                guard selectedIndex != Int.max else {
+                    return
+                }
+
+                pagingViewController.select(index: selectedIndex, animated: true)
             }
         }
 
@@ -167,12 +179,13 @@ import UIKit
                                       startingViewController _: UIViewController?,
                                       destinationViewController _: UIViewController,
                                       transitionSuccessful _: Bool) {
-                parent.onDidScroll?(pagingItem)
-
                 if let item = pagingItem as? Item,
                     let index = parent.items.firstIndex(where: { $0.isEqual(to: item) }) {
                     parent.selectedIndex = index
                 }
+
+                parent.onDidScroll?(pagingItem)
+
             }
 
             func pagingViewController(_: PagingViewController,


### PR DESCRIPTION
The SwiftUI wrapper had a bug where it would end up in the wrong page
when rotating the device. This only happend when not passing in a
$selectedIndex binding, which then defaults to a .constant(0) value
that will never be updated and therefore keep resetting the page to
the first page when rotating.