### PR TITLE
Add workaround for #canImport(Combine) being broken in Xcode 13 without bumping supported version

### DIFF
--- a/Parchment/Structs/PageView.swift
+++ b/Parchment/Structs/PageView.swift
@@ -7,7 +7,7 @@ import UIKit
 /// check. Found a possible fix here: https://stackoverflow.com/questions/58233454/how-to-use-swiftui-in-framework
 /// This might be related to the issue discussed in this thread:
 /// https://forums.swift.org/t/weak-linking-of-frameworks-with-greater-deployment-targets/26017/24
-#if canImport(SwiftUI) && canImport(Combine)
+#if canImport(SwiftUI) && !(os(iOS) && (arch(i386) || arch(arm)))
 
     /// `PageView` provides a SwiftUI wrapper around `PagingViewController`.
     /// It can be used with any fixed array of `PagingItem`s. Use the


### PR DESCRIPTION
It addresses reported issues #594, #599, and #600 if I'm not wrong. This changeset looks weird but it indeed succeeds in archiving using Xcode 13 without upgrading the existing minimum supported version.

Other major libraries (eg https://github.com/realm/realm-cocoa/pull/7401) also faced the same issue and addressed it like this.

Thanks!