### PR TITLE
Improve accessibility of default paging cell

### DIFF
--- a/Parchment/Classes/PagingTitleCell.swift
+++ b/Parchment/Classes/PagingTitleCell.swift
@@ -85,7 +85,7 @@ open class PagingTitleCell: PagingCell {
     open func configureAccessibility() {
         accessibilityIdentifier = viewModel?.title
         contentView.accessibilityLabel = viewModel?.title
-        contentView.accessibilityTraits = viewModel?.selected ?? false ? .selected : .none
+        contentView.accessibilityTraits = isCellSelected ?? false ? [.tabBar, .selected] : .tabBar
     }
 
     open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {


### PR DESCRIPTION
These elements should identify as tab structure and identify as tab 1 of 4, etc. – similar to how `UITabBar` does it. As it stands, a screen reader user would not be informed well enough to know how to interact with this system since this information is unexposed to them.