### PR TITLE
replace `PagingTitleItem` to `PagingIndexItem`

### DIFF
--- a/Documentation/data-source.md
+++ b/Documentation/data-source.md
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
 }
 ```
 
-In our data source implementation we set the number of view controllers equal to the number of items in our cities array, and return an instance of `PagingTitleItem` with the title of each city:
+In our data source implementation we set the number of view controllers equal to the number of items in our cities array, and return an instance of `PagingIndexItem` with the title of each city:
 
 ```Swift
 extension ViewController: PagingViewControllerDataSource {

--- a/Example/Examples/SizeDelegate/SizeDelegateViewController.swift
+++ b/Example/Examples/SizeDelegate/SizeDelegateViewController.swift
@@ -57,7 +57,7 @@ extension SizeDelegateViewController: PagingViewControllerSizeDelegate {
     // city title. Parchment does not support self-sizing cells at
     // the moment, so we have to handle the calculation ourself. We
     // can access the title string by casting the paging item to a
-    // PagingTitleItem, which is the PagingItem type used by
+    // PagingIndexItem, which is the PagingItem type used by
     // FixedPagingViewController.
     func pagingViewController(_ pagingViewController: PagingViewController, widthForPagingItem pagingItem: PagingItem, isSelected: Bool) -> CGFloat {
         guard let item = pagingItem as? PagingIndexItem else { return 0 }

--- a/Parchment/Classes/PagingTitleCell.swift
+++ b/Parchment/Classes/PagingTitleCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// A custom `PagingCell` implementation that only displays a text
-/// label. The title is based on the `PagingTitleItem` and the colors
+/// label. The title is based on the `PagingIndexItem` and the colors
 /// are based on the `PagingTheme` passed into `setPagingItem:`. When
 /// applying layout attributes it will interpolate between the default
 /// and selected text color based on the `progress` property.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ extension ViewController: PagingViewControllerDataSource {
     }
 
     func pagingViewController(_: PagingViewController, pagingItemAt index: Int) -> PagingItem {
-        return PagingTitleItem(title: "View \(index)", index: index)
+        return PagingIndexItem(title: "View \(index)", index: index)
     }
 }
 ```


### PR DESCRIPTION
In #401, `PagingTitleItem` was renamed to `PagingIndexItem`, but there was an omission in the change.  
I fixed it for replace `PagingTitleItem` to `PagingIndexItem`.