### PR TITLE
Fix issue with unsafe flags when using SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,7 @@ let package = Package(
     targets: [
         .target(
             name: "Parchment",
-            path: "Parchment",
-            linkerSettings: [
-                .unsafeFlags([
-                    "-weak_framework", "SwiftUI",
-                ]),
-            ]
-        ),
+            path: "Parchment"
+        )
     ]
 )

--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -1338,10 +1338,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					SwiftUI,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.martinrechsteiner.Parchment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1366,10 +1362,6 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"-weak_framework",
-					SwiftUI,
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.martinrechsteiner.Parchment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
In #615, -weak_framework SwiftUI was added as an unsafe compiler flag to the Swift package and Xcode project. This fixed an issue where you could not use Parchment on platforms that did not support SwiftUI. It turned out that this causes another issue where users cannot install Parchment using SwiftPM (reproducible by creating a new Xcode project with the SwiftUI template).

Removing this will probably bring back the other issue, but most people have started updating to iOS versions that support SwiftUI now. People still using older iOS version would have to target version 3.2.0, but that is probably fine as the majority of new features are likely to be SwiftUI improvements anyway.