### PR TITLE
Constrain menu to safe area insets by default

### DIFF
--- a/Example/Examples/Images/UnsplashViewController.swift
+++ b/Example/Examples/Images/UnsplashViewController.swift
@@ -34,12 +34,12 @@ class ImagePagingView: PagingView {
         NSLayoutConstraint.activate([
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            collectionView.topAnchor.constraint(equalTo: topAnchor),
+            collectionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
 
             pageView.leadingAnchor.constraint(equalTo: leadingAnchor),
             pageView.trailingAnchor.constraint(equalTo: trailingAnchor),
             pageView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            pageView.topAnchor.constraint(equalTo: topAnchor),
+            pageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
         ])
     }
 }

--- a/Example/Resources/UIView+constraints.swift
+++ b/Example/Resources/UIView+constraints.swift
@@ -55,51 +55,11 @@ extension UIView {
     func constrainToEdges(_ subview: UIView) {
         subview.translatesAutoresizingMaskIntoConstraints = false
 
-        let topContraint = NSLayoutConstraint(
-            item: subview,
-            attribute: .top,
-            relatedBy: .equal,
-            toItem: self,
-            attribute: .top,
-            multiplier: 1.0,
-            constant: 0
-        )
-
-        let bottomConstraint = NSLayoutConstraint(
-            item: subview,
-            attribute: .bottom,
-            relatedBy: .equal,
-            toItem: self,
-            attribute: .bottom,
-            multiplier: 1.0,
-            constant: 0
-        )
-
-        let leadingContraint = NSLayoutConstraint(
-            item: subview,
-            attribute: .leading,
-            relatedBy: .equal,
-            toItem: self,
-            attribute: .leading,
-            multiplier: 1.0,
-            constant: 0
-        )
-
-        let trailingContraint = NSLayoutConstraint(
-            item: subview,
-            attribute: .trailing,
-            relatedBy: .equal,
-            toItem: self,
-            attribute: .trailing,
-            multiplier: 1.0,
-            constant: 0
-        )
-
-        addConstraints([
-            topContraint,
-            bottomConstraint,
-            leadingContraint,
-            trailingContraint,
+        NSLayoutConstraint.activate([
+            subview.leadingAnchor.constraint(equalTo: leadingAnchor),
+            subview.trailingAnchor.constraint(equalTo: trailingAnchor),
+            subview.bottomAnchor.constraint(equalTo: bottomAnchor),
+            subview.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor)
         ])
     }
 }

--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -58,54 +58,18 @@ open class PagingView: UIView {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         pageView.translatesAutoresizingMaskIntoConstraints = false
 
-        let metrics = [
-            "height": options.menuHeight,
-        ]
+        let heightConstraint = collectionView.heightAnchor.constraint(equalToConstant: options.menuHeight)
+        heightConstraint.isActive = true
+        self.heightConstraint = heightConstraint
 
-        let views = [
-            "collectionView": collectionView,
-            "pageView": pageView,
-        ]
-
-        let formatOptions = NSLayoutConstraint.FormatOptions()
-
-        let horizontalCollectionViewContraints = NSLayoutConstraint.constraints(
-            withVisualFormat: "H:|[collectionView]|",
-            options: formatOptions,
-            metrics: metrics,
-            views: views
-        )
-
-        let horizontalPagingContentViewContraints = NSLayoutConstraint.constraints(
-            withVisualFormat: "H:|[pageView]|",
-            options: formatOptions,
-            metrics: metrics,
-            views: views
-        )
-
-        let verticalConstraintsFormat: String
-        switch options.menuPosition {
-        case .top:
-            verticalConstraintsFormat = "V:|[collectionView(==height)][pageView]|"
-        case .bottom:
-            verticalConstraintsFormat = "V:|[pageView][collectionView(==height)]|"
-        }
-
-        let verticalContraints = NSLayoutConstraint.constraints(
-            withVisualFormat: verticalConstraintsFormat,
-            options: formatOptions,
-            metrics: metrics,
-            views: views
-        )
-
-        addConstraints(horizontalCollectionViewContraints)
-        addConstraints(horizontalPagingContentViewContraints)
-        addConstraints(verticalContraints)
-
-        for constraint in verticalContraints {
-            if constraint.firstAttribute == NSLayoutConstraint.Attribute.height {
-                heightConstraint = constraint
-            }
-        }
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            collectionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: pageView.topAnchor),
+            pageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            pageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            pageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
     }
 }


### PR DESCRIPTION
This ensures that the menu is shown below the navigation bar by default. This could potentially break apps that expect this to be constrained to the top of the view, and they would need to provide their own PagingView subclass that overrides the constraints.