### PR TITLE
Fix PageViewController isScrollingFrom delegate when overshooting

### DIFF
--- a/Parchment/Classes/PageViewManager.swift
+++ b/Parchment/Classes/PageViewManager.swift
@@ -360,53 +360,25 @@ final class PageViewManager {
     }
 
     private func onScroll(progress: CGFloat) {
-        // This means we are overshooting, so we need to continue
-        // reporting the old view controllers.
-        if didReload {
-            switch initialDirection {
-            case .forward:
-                if let previousViewController = previousViewController,
-                    let selectedViewController = selectedViewController {
-                    delegate?.isScrolling(
-                        from: previousViewController,
-                        to: selectedViewController,
-                        progress: progress
-                    )
-                }
-            case .reverse:
-                if let nextViewController = nextViewController,
-                    let selectedViewController = selectedViewController {
-                    delegate?.isScrolling(
-                        from: nextViewController,
-                        to: selectedViewController,
-                        progress: progress
-                    )
-                }
-            case .none:
-                break
+        switch initialDirection {
+        case .forward:
+            if let selectedViewController = selectedViewController {
+                delegate?.isScrolling(
+                    from: selectedViewController,
+                    to: nextViewController,
+                    progress: progress
+                )
             }
-        } else {
-            // Report progress as normally
-            switch initialDirection {
-            case .forward:
-                if let selectedViewController = selectedViewController {
-                    delegate?.isScrolling(
-                        from: selectedViewController,
-                        to: nextViewController,
-                        progress: progress
-                    )
-                }
-            case .reverse:
-                if let selectedViewController = selectedViewController {
-                    delegate?.isScrolling(
-                        from: selectedViewController,
-                        to: previousViewController,
-                        progress: progress
-                    )
-                }
-            case .none:
-                break
+        case .reverse:
+            if let selectedViewController = selectedViewController {
+                delegate?.isScrolling(
+                    from: selectedViewController,
+                    to: previousViewController,
+                    progress: progress
+                )
             }
+        case .none:
+            break
         }
     }
 

--- a/ParchmentTests/PageViewManagerTests.swift
+++ b/ParchmentTests/PageViewManagerTests.swift
@@ -737,12 +737,12 @@ final class PageViewManagerTests: XCTestCase {
         manager.didScroll(progress: -0.01)
 
         // Expect that it triggers .isScrolling events for scroll events
-        // when overshooting, but does not trigger appereance transitions
+        // when overshooting, but does not trigger appearance transitions
         // for the next upcoming view (viewController3).
         XCTAssertEqual(delegate.calls, [
-            .isScrolling(from: viewController1, to: viewController2, progress: 0.0),
-            .isScrolling(from: viewController1, to: viewController2, progress: 0.01),
-            .isScrolling(from: viewController1, to: viewController2, progress: -0.01),
+            .isScrolling(from: viewController2, to: viewController3, progress: 0.0),
+            .isScrolling(from: viewController2, to: viewController3, progress: 0.01),
+            .isScrolling(from: viewController2, to: viewController3, progress: -0.01),
         ])
     }
 


### PR DESCRIPTION
When swiping fast to the next view controller, the scroll view will overshoot and trigger additional isScrollingFrom methods after didFinishScrollingFrom is called. This is expected, but the view controllers that are returned are the previously selected view controller and not the upcoming view controller. This was done to avoid triggered view controller appearance method (like viewWillAppear) for the upcoming view controllers when overshooting, but it seems like this is not happening anymore, so we can just remove this workaround.