### PR TITLE
Drop iOS 13 for SwiftUI views and use UIContentConfiguration

### DIFF
--- a/Parchment.xcodeproj/project.pbxproj
+++ b/Parchment.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		950ABE452438975300CAD458 /* PageViewExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950ABE442438975300CAD458 /* PageViewExampleViewController.swift */; };
 		951E163720A21D3A0055E9D4 /* PagingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842601F4251F90072038C /* PagingViewControllerTests.swift */; };
 		952D802F1E37CC09003DCB18 /* PagingTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 952D802E1E37CC09003DCB18 /* PagingTransition.swift */; };
+		9530E25329DEC2E5004FC88C /* PageContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9530E25229DEC2E5004FC88C /* PageContentConfiguration.swift */; };
 		953B8D352416C3DC0047BBA1 /* SelfSizingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953B8D342416C3DC0047BBA1 /* SelfSizingViewController.swift */; };
 		954842591F42438E0072038C /* PagingInvalidationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 954842581F42438E0072038C /* PagingInvalidationContext.swift */; };
 		9548425D1F42486B0072038C /* PagingDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9548425C1F42486B0072038C /* PagingDiff.swift */; };
@@ -258,6 +259,7 @@
 		950ABE412437BD4D00CAD458 /* PagingNavigationOrientation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingNavigationOrientation.swift; sourceTree = "<group>"; };
 		950ABE442438975300CAD458 /* PageViewExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewExampleViewController.swift; sourceTree = "<group>"; };
 		952D802E1E37CC09003DCB18 /* PagingTransition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingTransition.swift; sourceTree = "<group>"; };
+		9530E25229DEC2E5004FC88C /* PageContentConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageContentConfiguration.swift; sourceTree = "<group>"; };
 		953B8D342416C3DC0047BBA1 /* SelfSizingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSizingViewController.swift; sourceTree = "<group>"; };
 		954842581F42438E0072038C /* PagingInvalidationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingInvalidationContext.swift; sourceTree = "<group>"; };
 		9548425C1F42486B0072038C /* PagingDiff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagingDiff.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 				956FFFC729BD792100477E94 /* PageItemCell.swift */,
 				956FFFC929BE090800477E94 /* PageItem.swift */,
 				956FFFCD29BE235200477E94 /* PagingControllerRepresentableView.swift */,
+				9530E25229DEC2E5004FC88C /* PageContentConfiguration.swift */,
 			);
 			path = Structs;
 			sourceTree = "<group>";
@@ -1060,6 +1063,7 @@
 				3E2AAD281CA831AB0044AAA5 /* UIView+constraints.swift in Sources */,
 				95D2AE6F242EA3EF00AC3D46 /* PageViewControllerDelegate.swift in Sources */,
 				95A84B0520E586FA0031520F /* PagingStaticDataSource.swift in Sources */,
+				9530E25329DEC2E5004FC88C /* PageContentConfiguration.swift in Sources */,
 				3E49C7251C8F5C13006269DD /* PagingBorderView.swift in Sources */,
 				E8CB720A23D70E1400A9B089 /* PagingMenuPosition.swift in Sources */,
 				95E4BA721FF15EFE008871A3 /* PagingFiniteDataSource.swift in Sources */,

--- a/Parchment/Classes/PageViewCoordinator.swift
+++ b/Parchment/Classes/PageViewCoordinator.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@available(iOS 13.0, *)
+@available(iOS 14.0, *)
 final class PageViewCoordinator: PagingViewControllerDataSource, PagingViewControllerDelegate {
     var parent: PagingControllerRepresentableView
 

--- a/Parchment/Classes/PagingView.swift
+++ b/Parchment/Classes/PagingView.swift
@@ -60,16 +60,29 @@ open class PagingView: UIView {
 
         let heightConstraint = collectionView.heightAnchor.constraint(equalToConstant: options.menuHeight)
         heightConstraint.isActive = true
+        heightConstraint.priority = .defaultHigh
         self.heightConstraint = heightConstraint
 
         NSLayoutConstraint.activate([
             collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            collectionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            collectionView.bottomAnchor.constraint(equalTo: pageView.topAnchor),
             pageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            pageView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            pageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            pageView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
+
+        switch options.menuPosition {
+        case .top:
+            NSLayoutConstraint.activate([
+                collectionView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+                pageView.topAnchor.constraint(equalTo: collectionView.bottomAnchor),
+                pageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            ])
+        case .bottom:
+            NSLayoutConstraint.activate([
+                pageView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+                pageView.bottomAnchor.constraint(equalTo: collectionView.topAnchor),
+                collectionView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor)
+            ])
+        }
     }
 }

--- a/Parchment/Structs/PageContentConfiguration.swift
+++ b/Parchment/Structs/PageContentConfiguration.swift
@@ -1,0 +1,108 @@
+import UIKit
+import SwiftUI
+
+@available(iOS 14.0, *)
+struct PageContentConfiguration<Content: View>: UIContentConfiguration {
+    let content: Content
+    var margins: NSDirectionalEdgeInsets
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+        self.margins = .zero
+    }
+
+    func makeContentView() -> UIView & UIContentView {
+        return PageContentView(configuration: self)
+    }
+
+    func updated(for state: UIConfigurationState) -> PageContentConfiguration<Content> {
+        return self
+    }
+
+    func margins(_ edges: SwiftUI.Edge.Set = .all, _ length: CGFloat) -> PageContentConfiguration<Content> {
+        var configuration = self
+        configuration.margins = NSDirectionalEdgeInsets(
+            top: edges.contains(.top) ? length : margins.top,
+            leading: edges.contains(.leading) ? length : margins.leading,
+            bottom: edges.contains(.bottom) ? length : margins.bottom,
+            trailing: edges.contains(.trailing) ? length : margins.trailing
+        )
+        return configuration
+    }
+}
+
+@available(iOS 14.0, *)
+final class PageContentView<Content: View>: UIView, UIContentView {
+    var configuration: UIContentConfiguration {
+        didSet {
+            if let configuration = configuration as? PageContentConfiguration<Content> {
+                margins = configuration.margins
+                hostingController.rootView = configuration.content
+                directionalLayoutMargins = configuration.margins
+            }
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        return sizeThatFits(UIView.layoutFittingCompressedSize)
+    }
+
+    override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let size = hostingController.sizeThatFits(in: size)
+        return CGSize(
+            width: size.width + margins.leading + margins.trailing,
+            height: size.height + margins.top + margins.bottom
+        )
+    }
+
+    private var margins: NSDirectionalEdgeInsets
+    private let hostingController: UIHostingController<Content>
+
+    init(configuration: PageContentConfiguration<Content>) {
+        self.configuration = configuration
+        self.hostingController = UIHostingController(rootView: configuration.content)
+        self.margins = configuration.margins
+        super.init(frame: .zero)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window == nil {
+            hostingController.willMove(toParent: nil)
+            hostingController.removeFromParent()
+            hostingController.didMove(toParent: nil)
+        } else if let parent = parentViewController() {
+            hostingController.willMove(toParent: parent)
+            parent.addChild(hostingController)
+            hostingController.didMove(toParent: parent)
+        }
+    }
+
+    private func configure() {
+        hostingController.view.backgroundColor = .clear
+        addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor)
+        ])
+    }
+
+    private func parentViewController() -> UIViewController? {
+        var responder: UIResponder? = self
+        while let nextResponder = responder?.next {
+            if let viewController = nextResponder as? UIViewController {
+                return viewController
+            }
+            responder = nextResponder
+        }
+        return nil
+    }
+}

--- a/Parchment/Structs/PageItem.swift
+++ b/Parchment/Structs/PageItem.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@available(iOS 13.0, *)
+@available(iOS 14.0, *)
 struct PageItem: PagingItem, Hashable, Comparable {
     let identifier: Int
     let index: Int

--- a/Parchment/Structs/PageItemBuilder.swift
+++ b/Parchment/Structs/PageItemBuilder.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@available(iOS 13.0, *)
+@available(iOS 14.0, *)
 @resultBuilder
 public struct PageBuilder {
     public static func buildExpression(_ expression: Page) -> [Page] {

--- a/Parchment/Structs/PageItemCell.swift
+++ b/Parchment/Structs/PageItemCell.swift
@@ -1,81 +1,28 @@
 import UIKit
 import Foundation
 
-@available(iOS 13.0, *)
+@available(iOS 14.0, *)
 final class PageItemCell: PagingCell {
-    private var item: PageItem!
+    private var page: Page!
     private var options: PagingOptions?
     private var itemSelected: Bool = false
-    private var hostingController: UIViewController?
-
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        if hostingController?.parent == nil {
-            addHostingController()
-        }
-    }
-
-    override func systemLayoutSizeFitting(
-        _ targetSize: CGSize,
-        withHorizontalFittingPriority horizontalFittingPriority: UILayoutPriority,
-        verticalFittingPriority: UILayoutPriority
-    ) -> CGSize {
-        guard let hostingController else { return .zero }
-
-        return hostingController.view.systemLayoutSizeFitting(
-            targetSize,
-            withHorizontalFittingPriority: .fittingSizeLevel,
-            verticalFittingPriority: .defaultLow
-        )
-    }
 
     override func setPagingItem(_ pagingItem: PagingItem, selected: Bool, options: PagingOptions) {
-        item = pagingItem as? PageItem
+        let item = pagingItem as! PageItem
+        let state = PageState(progress: selected ? 1 : 0, isSelected: selected)
+
+        self.page = item.page
         self.options = options
         self.itemSelected = selected
 
-        if let hostingController = hostingController {
-            let state = PageState(progress: selected ? 1 : 0, isSelected: selected)
-            item.page.header(options, state, hostingController)
-        }
+        contentConfiguration = page.header(options, state)
     }
 
     override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
         super.apply(layoutAttributes)
-        if let attributes = layoutAttributes as? PagingCellLayoutAttributes {
-            if let hostingController, let options {
-                let state = PageState(progress: attributes.progress, isSelected: itemSelected)
-                item.page.header(options, state, hostingController)
-            }
+        if let attributes = layoutAttributes as? PagingCellLayoutAttributes, let options = options {
+            let state = PageState(progress: attributes.progress, isSelected: itemSelected)
+            contentConfiguration = page.header(options, state)
         }
-    }
-
-    private func addHostingController() {
-        if let item = item,
-           let options = options,
-           let parentViewController = parentViewController() {
-            let viewController = item.page.headerHostingController(options)
-            viewController.view.backgroundColor = options.backgroundColor
-            viewController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            viewController.view.frame = contentView.bounds
-            contentView.addSubview(viewController.view)
-            parentViewController.addChild(viewController)
-            viewController.didMove(toParent: parentViewController)
-            hostingController = viewController
-
-            let state = PageState(progress: itemSelected ? 1 : 0, isSelected: itemSelected)
-            item.page.header(options, state, viewController)
-        }
-    }
-
-    private func parentViewController() -> UIViewController? {
-        var responder: UIResponder? = self
-        while let nextResponder = responder?.next {
-            if let viewController = nextResponder as? UIViewController {
-                return viewController
-            }
-            responder = nextResponder
-        }
-        return nil
     }
 }

--- a/Parchment/Structs/PageView.swift
+++ b/Parchment/Structs/PageView.swift
@@ -21,7 +21,7 @@ import UIKit
 ///     }
 /// }
 /// ```
-@available(iOS 13.0, *)
+@available(iOS 14.0, *)
 public struct PageView: View {
     private let items: [PagingItem]
     private var content: ((PagingItem) -> UIViewController)?
@@ -182,7 +182,7 @@ public struct PageView: View {
     }
 }
 
-@available(iOS 13.0, *)
+@available(iOS 14.0, *)
 extension PageView {
     /// Called when the user finished scrolling to a new view.
     ///

--- a/Parchment/Structs/PagingControllerRepresentableView.swift
+++ b/Parchment/Structs/PagingControllerRepresentableView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import SwiftUI
 
-@available(iOS 13.0, *)
+@available(iOS 14.0, *)
 struct PagingControllerRepresentableView: UIViewControllerRepresentable {
     let items: [PagingItem]
     let content: ((PagingItem) -> UIViewController)?
@@ -25,7 +25,10 @@ struct PagingControllerRepresentableView: UIViewControllerRepresentable {
 
         if let items = items as? [PageItem] {
             for item in items {
-                item.page.registerCell(pagingViewController.collectionView)
+                pagingViewController.collectionView.register(
+                    PageItemCell.self,
+                    forCellWithReuseIdentifier: item.page.reuseIdentifier
+                )
             }
         }
 

--- a/ParchmentTests/PagingControllerTests.swift
+++ b/ParchmentTests/PagingControllerTests.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import Parchment
 import XCTest
 
+@MainActor
 final class PagingControllerTests: XCTestCase {
     static let ItemSize: CGFloat = 50
 


### PR DESCRIPTION
By increasing the minimum target for the SwiftUI views to iOS 14, we can use UIContentConfiguration to simplify the integration between UIKit and SwiftUI. We can now use the new UIHostingConfiguration on iOS 16 and fall back to UIHostingController using a custom UIContentConfiguration on older versions.