### PR TITLE
Add new PagingIndexable protocol to allow comparison between items

### DIFF
--- a/Example/Examples/Icons/IconsViewController.swift
+++ b/Example/Examples/Icons/IconsViewController.swift
@@ -1,30 +1,17 @@
 import Parchment
 import UIKit
 
-struct IconItem: PagingItem, Hashable {
+struct IconItem: PagingItem, PagingIndexable, Hashable {
+    let identifier: Int
     let icon: String
     let index: Int
     let image: UIImage?
 
     init(icon: String, index: Int) {
+        self.identifier = icon.hashValue
         self.icon = icon
         self.index = index
-        image = UIImage(named: icon)
-    }
-
-    /// By default, isBefore is implemented when the PagingItem conforms
-    /// to Comparable, but in this case we want a custom implementation
-    /// where we also compare IconItem with PagingIndexItem. This
-    /// ensures that we animate the page transition in the correct
-    /// direction when selecting items.
-    func isBefore(item: PagingItem) -> Bool {
-        if let item = item as? PagingIndexItem {
-            return index < item.index
-        } else if let item = item as? Self {
-            return index < item.index
-        } else {
-            return false
-        }
+        self.image = UIImage(named: icon)
     }
 }
 
@@ -64,7 +51,7 @@ class IconsViewController: UIViewController {
         pagingViewController.select(pagingItem: IconItem(icon: icons[0], index: 0))
 
         // Add the paging view controller as a child view controller
-        // and contrain it to all edges.
+        // and constrain it to all edges.
         addChild(pagingViewController)
         view.addSubview(pagingViewController.view)
         view.constrainToEdges(pagingViewController.view)

--- a/Parchment/Protocols/PagingItem.swift
+++ b/Parchment/Protocols/PagingItem.swift
@@ -29,3 +29,26 @@ extension PagingItem where Self: Hashable {
         return hashValue
     }
 }
+
+/// The PagingIndexable protocol is used to compare items in your
+/// menu. Conform to this protocol when you need to mix multiple
+/// PagingItem types that all need to be compared.
+//
+/// The PagingIndexable protocol requires the conforming type to
+/// provide an index property of type Int, which is used to compare
+/// items in the menu.
+///
+/// For example, if you have a menu that contains both PagingIndexItem
+/// and PagingImageItem types, you can conform both types to
+/// PagingIndexable and Parchment will provide a default
+/// implementation that will be used to animate between them.
+public protocol PagingIndexable {
+    var index: Int { get }
+}
+
+extension PagingItem where Self: PagingIndexable {
+    public func isBefore(item: PagingItem) -> Bool {
+        guard let item = item as? PagingIndexable else { return false }
+        return index < item.index
+    }
+}

--- a/Parchment/Structs/PagingIndexItem.swift
+++ b/Parchment/Structs/PagingIndexItem.swift
@@ -3,7 +3,7 @@ import UIKit
 /// An implementation of the `PagingItem` protocol that stores the
 /// index and title of a given item. The index property is needed to
 /// make the `PagingItem` comparable.
-public struct PagingIndexItem: PagingItem, Hashable, Comparable {
+public struct PagingIndexItem: PagingItem, PagingIndexable, Hashable {
     /// The index of the `PagingItem` instance
     public let index: Int
 
@@ -17,9 +17,5 @@ public struct PagingIndexItem: PagingItem, Hashable, Comparable {
     public init(index: Int, title: String) {
         self.index = index
         self.title = title
-    }
-
-    public static func < (lhs: PagingIndexItem, rhs: PagingIndexItem) -> Bool {
-        return lhs.index < rhs.index
     }
 }


### PR DESCRIPTION
When Parchment selects items outside of the visibleItems range, it needs to know whether that it is before or after the selected item so it can animate in the correct direction.

This worked fine when all items where of the same type, but if you mixed multiple types they needed to know about each other. If you used the build-in PagingIndexItem, it would not know about your custom items and the animation would be wrong. This is now fixed by introducing a new PagingIndexable protocol that PagingIndexItem used to compare itself against. This can then be used by custom items, like in the IconItem example.