### PR TITLE
Fix rotation and crash issues with calling layoutIfNeeded 

### DIFF
--- a/Example/ExamplesViewController.swift
+++ b/Example/ExamplesViewController.swift
@@ -148,4 +148,15 @@ final class NavigationController: UINavigationController {
         navigationBar.compactAppearance = appearance
         navigationBar.scrollEdgeAppearance = appearance
     }
+
+    // For debugging purposes. Adds a hook to push a new view
+    // controller to debug navigation controller related issues.
+    override func motionBegan(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            let viewController = UIViewController()
+            viewController.title = "Page"
+            viewController.view.backgroundColor = .white
+            pushViewController(viewController, animated: true)
+        }
+    }
 }

--- a/Example/Resources/Base.lproj/Main.storyboard
+++ b/Example/Resources/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="q4m-KO-mBR">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ti2-Oh-iiB">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -9,16 +9,21 @@
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
-        <scene sceneID="UJ4-9T-uzW">
+        <scene sceneID="KMO-vS-UdG">
             <objects>
-                <navigationController extendedLayoutIncludesOpaqueBars="YES" id="q4m-KO-mBR" customClass="NavigationController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
-                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
-                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" translucent="NO" prompted="NO"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" translucent="NO" id="Tuq-Hd-LFa">
+                <navigationController id="ti2-Oh-iiB" customClass="NavigationController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Qw0-yq-kTw">
                         <rect key="frame" x="0.0" y="48" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
+                        <color key="backgroundColor" systemColor="linkColor"/>
                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <color key="barTintColor" systemColor="linkColor"/>
+                        <color key="barTintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <textAttributes key="titleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
+                        <textAttributes key="largeTitleTextAttributes">
+                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </textAttributes>
                         <navigationBarAppearance key="standardAppearance">
                             <color key="backgroundColor" systemColor="linkColor"/>
                             <textAttributes key="titleTextAttributes">
@@ -27,6 +32,9 @@
                         </navigationBarAppearance>
                         <navigationBarAppearance key="compactAppearance">
                             <color key="backgroundColor" systemColor="linkColor"/>
+                            <textAttributes key="titleTextAttributes">
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </textAttributes>
                         </navigationBarAppearance>
                         <navigationBarAppearance key="scrollEdgeAppearance">
                             <color key="backgroundColor" systemColor="linkColor"/>
@@ -36,19 +44,19 @@
                         </navigationBarAppearance>
                     </navigationBar>
                     <connections>
-                        <segue destination="zQo-ny-4EL" kind="relationship" relationship="rootViewController" id="EWy-YM-lkZ"/>
+                        <segue destination="zQo-ny-4EL" kind="relationship" relationship="rootViewController" id="U3Y-LD-KMp"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="6Qm-qq-xBM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0QX-Wb-stH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-483" y="322"/>
+            <point key="canvasLocation" x="-536" y="321"/>
         </scene>
         <!--Examples-->
         <scene sceneID="Skl-JE-8hv">
             <objects>
                 <tableViewController id="zQo-ny-4EL" customClass="ExamplesViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="qJk-Tf-P33">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="804"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>

--- a/Parchment/Classes/PageViewController.swift
+++ b/Parchment/Classes/PageViewController.swift
@@ -35,12 +35,6 @@ public final class PageViewController: UIViewController {
     public private(set) lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.isPagingEnabled = true
-        scrollView.autoresizingMask = [
-            .flexibleTopMargin,
-            .flexibleRightMargin,
-            .flexibleBottomMargin,
-            .flexibleLeftMargin,
-        ]
         scrollView.scrollsToTop = false
         scrollView.bounces = true
         scrollView.translatesAutoresizingMaskIntoConstraints = true
@@ -140,12 +134,19 @@ public final class PageViewController: UIViewController {
         view.addSubview(scrollView)
         scrollView.delegate = self
         scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+        ])
     }
 
-    public override func viewWillLayoutSubviews() {
-        super.viewWillLayoutSubviews()
-        scrollView.frame = view.bounds
-        manager.viewWillLayoutSubviews()
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        manager.viewDidLayoutSubviews()
     }
 
     public override func viewWillAppear(_ animated: Bool) {
@@ -301,10 +302,6 @@ extension PageViewController: PageViewManagerDelegate {
 
     func layoutViews(for viewControllers: [UIViewController], keepContentOffset: Bool) {
         let viewControllers = isRightToLeft ? viewControllers.reversed() : viewControllers
-
-        // Need to trigger a layout here to ensure that the scroll view
-        // bounds is updated before we use its frame for calculations.
-        view.layoutIfNeeded()
 
         for (index, viewController) in viewControllers.enumerated() {
             switch options.contentNavigationOrientation {

--- a/Parchment/Classes/PageViewManager.swift
+++ b/Parchment/Classes/PageViewManager.swift
@@ -154,8 +154,8 @@ final class PageViewManager {
         }
     }
 
-    func viewWillLayoutSubviews() {
-        layoutsViews()
+    func viewDidLayoutSubviews() {
+        layoutsViews(keepContentOffset: false)
     }
 
     func viewWillAppear(_ animated: Bool) {
@@ -170,7 +170,7 @@ final class PageViewManager {
 
         switch state {
         case .center, .first, .last, .single:
-            layoutsViews()
+            layoutsViews(keepContentOffset: false)
         case .empty:
             break
         }

--- a/Parchment/Classes/PagingViewController.swift
+++ b/Parchment/Classes/PagingViewController.swift
@@ -287,6 +287,7 @@ open class PagingViewController:
 
     private let pagingController: PagingController
     private var didLayoutSubviews: Bool = false
+    private var didTransitionSize: Bool = false
 
     private var pagingView: PagingView {
         return view as! PagingView
@@ -488,6 +489,20 @@ open class PagingViewController:
         configureContentInteraction()
     }
 
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if #unavailable(iOS 16), didTransitionSize {
+            view.layoutIfNeeded()
+            pagingController.transitionSize()
+        }
+    }
+
+    open override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        didTransitionSize = false
+        didLayoutSubviews = false
+    }
+
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
@@ -502,9 +517,10 @@ open class PagingViewController:
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
+        didTransitionSize = true
         coordinator.animate(alongsideTransition: { _ in
             self.pagingController.transitionSize()
-    }, completion: nil)
+        })
     }
 
     /// Register cell class for paging cell


### PR DESCRIPTION
Calling layoutIfNeeded when laying out the page view sometimes caused
apps to crash when this was done while hidden. It also does not work
when rotating the device while another view is pushing.