### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Parchment lets you page between view controllers while showing any type of gener
   - [Reloading data](#reloading-data)
   - [Delegate](#delegate)
   - [Size delegate](#size-delegate)
-  - [Selecting items](#selecting-items)
 - [Customization](#customization)
 - [Installation](#installation)
 - [Changelog](#changelog)


### PR DESCRIPTION
There was the same link in README, so I removed one of them.

<a href="https://github.com/rechsteiner/Parchment/assets/26753/01387615-af82-4377-877e-b9f343e8a977"><img src="https://github.com/rechsteiner/Parchment/assets/26753/01387615-af82-4377-877e-b9f343e8a977" width="70%" /></a>