### PR TITLE
Release v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 `Parchment` adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.0.0](https://github.com/rechsteiner/Parchment/compare/v3.4.0...v4.0.0) - 2024-05-25
+
+Version 4.0 introduced a new and improved API for PageView in SwiftUI. Each page can now show define their own menu items, which can be any SwiftUI view. The new API also supports result builders, which allows you to easily setup your PageView.
+
+```swift
+PageView {
+    Page("Title 1") {
+        Text("Page 1")
+    }
+    Page { _ in
+        Image(systemName: "star.fill")
+    } content: {
+        Text("Page 2")
+    }
+}
+```
+
+## Changes
+
+- New API for PageView in SwiftUI #666
+- Updated minimum deployment target to iOS 11 #661
+- Constrain menu to safe area insets by default #668
+
+## Added
+
+- Add support for custom SwiftUI styles for indicator views #684
+- Add horizontal right alignment support #658
+- Add missing color modifiers to PageView #675
+- Add new PagingIndexable protocol to allow comparison between items #678
+
+## Fixes
+
+- Fix PageViewController isScrollingFrom delegate when overshooting #669
+- Fix didSelectItem delegate being called before actual selection #676
+- Fix setting PageView closures multiple times #677
+- Fix rotation and crash issues with calling layoutIfNeeded #680
+- Fix options not propagating changes when SwiftUI view is updated #697
+
 ## [3.4.0](https://github.com/rechsteiner/Parchment/compare/v3.3.0...v3.4.0) - 2024-04-14
 
 - Update Swift version to 5.10 #705

--- a/Parchment.podspec.json
+++ b/Parchment.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Parchment",
-  "version": "3.4.0",
+  "version": "4.0.0",
   "license": "MIT",
   "summary": "A flexible paging menu controller with support for infinite data sources.",
     "description": "Parchment allows you to page between view controllers while showing menu items that scrolls along with the content. It’s build to be very customizable, it’s well-tested and written fully in Swift.",
@@ -8,7 +8,7 @@
   "authors": "Martin Rechsteiner",
   "source": {
     "git": "https://github.com/rechsteiner/Parchment.git",
-    "tag": "v3.4.0"
+    "tag": "v4.0.0"
   },
   "swift_version": "5.10",
   "platforms": {

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ Parchment will be compatible with the lastest public release of Swift.
 Parchment is available through [CocoaPods](https://cocoapods.org). To install it, add the following to your `Podfile`:
 
 ```
-pod 'Parchment', '~> 3.4'
+pod 'Parchment', '~> 4.0'
 ```
 
 ### Swift Package Manager
@@ -628,7 +628,7 @@ pod 'Parchment', '~> 3.4'
 Parchment is available through [Swift Package Manager](https://swift.org/package-manager/). Add Parchment as a dependency to your `Package.swift`:
 
 ```Swift
-.package(url: "https://github.com/rechsteiner/Parchment", from: "3.4.0")
+.package(url: "https://github.com/rechsteiner/Parchment", from: "4.0.0")
 ```
 
 ### Carthage
@@ -636,7 +636,7 @@ Parchment is available through [Swift Package Manager](https://swift.org/package
 Parchment also supports [Carthage](https://github.com/Carthage/Carthage). To install it, add the following to your `Cartfile`:
 
 ```
-github "rechsteiner/Parchment" ~> 3.4
+github "rechsteiner/Parchment" ~> 4.0
 ```
 
 See [this guide](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application) for more details on using Carthage.


### PR DESCRIPTION
Version 4.0 introduced a new and improved API for PageView in SwiftUI. Each page can now show define their own menu items, which can be any SwiftUI view. The new API also supports result builders, which allows you to easily setup your PageView.

```swift
PageView {
    Page("Title 1") {
        Text("Page 1")
    }
    Page { _ in
        Image(systemName: "star.fill")
    } content: {
        Text("Page 2")
    }
}
```

## Changes

- New API for PageView in SwiftUI #666
- Updated minimum deployment target to iOS 11 #661
- Constrain menu to safe area insets by default #668

## Added

- Add support for custom SwiftUI styles for indicator views #684
- Add horizontal right alignment support #658
- Add missing color modifiers to PageView #675
- Add new PagingIndexable protocol to allow comparison between items #678

## Fixes

- Fix PageViewController isScrollingFrom delegate when overshooting #669
- Fix didSelectItem delegate being called before actual selection #676
- Fix setting PageView closures multiple times #677
- Fix rotation and crash issues with calling layoutIfNeeded #680
- Fix options not propagating changes when SwiftUI view is updated #697